### PR TITLE
feat(ci): attested image delivery via central sign/verify workflows

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -63,10 +63,12 @@ jobs:
       - name: Parse coverage percentage
         id: coverage
         run: |
-          COVERAGE=$(cargo llvm-cov --all-features \
-            --workspace --summary-only \
-            | grep -oP 'TOTAL\s+\d+\.\d+%' \
-            | grep -oP '\d+\.\d+' || echo "0")
+          # Parse the JSON report generated above; the summary-table
+          # TOTAL row puts an integer region count first, so a
+          # 'TOTAL <float>%' grep never matches and reported 0%.
+          COVERAGE=$(jq -r \
+            '.data[0].totals.lines.percent * 100 | round / 100' \
+            coverage.json || echo "0")
           echo "percentage=$COVERAGE" >> "$GITHUB_OUTPUT"
           echo "Coverage: ${COVERAGE}%"
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -72,6 +72,19 @@ jobs:
       || inputs.stage == 'ci'))
     uses: ./.github/workflows/ci-test-matrix.yml
 
+  # Required check context: "pin-check / pin-check" — asserts every
+  # `uses:` reference is pinned to a full 40-char commit SHA.
+  pin-check:
+    if: >-
+      github.event_name != 'workflow_dispatch'
+      || inputs.stage == 'all'
+      || inputs.stage == 'ci'
+    permissions:
+      contents: read
+    # zircote/.github main (2026-06-11)
+    uses: >-
+      zircote/.github/.github/workflows/pin-check.yml@e8f0dbde068cc0701e443e7b8d57ae9917de7da3
+
   # -----------------------------------------------------------
   # Docker — after CI; PR = build-only, push on main/tags
   # -----------------------------------------------------------
@@ -88,11 +101,58 @@ jobs:
         ${{ github.event_name != 'pull_request' }}
 
   # -----------------------------------------------------------
-  # Release Stage — tags only
+  # Image attestation — centralized signer (SLSA Build L3
+  # isolation boundary), then a fail-closed verify gate
+  # -----------------------------------------------------------
+  docker-sign:
+    name: Sign and Attest Image
+    needs: [docker]
+    if: >-
+      github.event_name != 'pull_request'
+      && (github.event_name != 'workflow_dispatch'
+      || inputs.stage == 'all'
+      || inputs.stage == 'docker')
+    permissions:
+      id-token: write
+      attestations: write
+      packages: write
+      contents: read
+    # zircote/.github main (2026-06-11)
+    uses: >-
+      zircote/.github/.github/workflows/sign-and-attest.yml@e8f0dbde068cc0701e443e7b8d57ae9917de7da3
+    with:
+      image-name: ghcr.io/${{ github.repository }}
+      image-digest: ${{ needs.docker.outputs.image-digest }}
+
+  docker-verify:
+    name: Verify Image Attestations
+    needs: [docker, docker-sign]
+    if: >-
+      github.event_name != 'pull_request'
+      && (github.event_name != 'workflow_dispatch'
+      || inputs.stage == 'all'
+      || inputs.stage == 'docker')
+    permissions:
+      id-token: write
+      attestations: read
+      packages: read
+      contents: read
+    # zircote/.github main (2026-06-11)
+    uses: >-
+      zircote/.github/.github/workflows/verify-attestation.yml@e8f0dbde068cc0701e443e7b8d57ae9917de7da3
+    with:
+      image-ref: >-
+        ghcr.io/${{ github.repository }}@${{
+        needs.docker.outputs.image-digest }}
+      attestation-repo: ${{ github.repository }}
+
+  # -----------------------------------------------------------
+  # Release Stage — tags only; gated on the fail-closed verify
+  # so a tag publishes nothing unsigned
   # -----------------------------------------------------------
   release:
     name: Create Release
-    needs: [ci]
+    needs: [ci, docker-verify]
     if: >-
       (github.ref_type == 'tag'
       && startsWith(github.ref, 'refs/tags/v'))
@@ -164,10 +224,12 @@ jobs:
       tag: ${{ github.ref_name }}
 
   # -----------------------------------------------------------
-  # SLSA — inline jobs (cannot nest reusable workflow calls)
+  # SLSA — provenance for the released binaries via GitHub
+  # artifact attestations; attests the published assets, not a
+  # rebuild. Verify: gh attestation verify <file> --repo <o>/<r>
   # -----------------------------------------------------------
-  slsa-build:
-    name: SLSA Build and Hash
+  slsa-binaries:
+    name: Attest Release Binaries
     needs: [release]
     if: >-
       (github.ref_type == 'tag'
@@ -176,48 +238,26 @@ jobs:
       && (inputs.stage == 'all'
       || inputs.stage == 'slsa'))
     runs-on: ubuntu-latest
-    outputs:
-      hashes: ${{ steps.hash.outputs.hashes }}
-    steps:
-      - name: Checkout code
-        # v6.0.2
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-
-      - name: Setup Rust
-        # master
-        uses: >-
-          dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-        with:
-          toolchain: stable
-
-      - name: Build release binary
-        run: cargo build --release
-
-      - name: Generate subject hashes
-        id: hash
-        run: |
-          set -euo pipefail
-          HASHES=$(sha256sum \
-            target/release/rust_template \
-            | base64 -w0)
-          echo "hashes=${HASHES}" >> "$GITHUB_OUTPUT"
-
-  slsa-provenance:
-    name: SLSA Provenance
-    needs: [slsa-build]
-    if: >-
-      (github.ref_type == 'tag'
-      && startsWith(github.ref, 'refs/tags/v'))
-      || (github.event_name == 'workflow_dispatch'
-      && (inputs.stage == 'all'
-      || inputs.stage == 'slsa'))
     permissions:
-      actions: read
+      contents: read
       id-token: write
-      contents: write
-    uses: >-
-      slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
-    with:
-      base64-subjects: >-
-        ${{ needs.slsa-build.outputs.hashes }}
-      upload-assets: true
+      attestations: write
+    steps:
+      - name: Download release binaries
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh release download "$TAG" \
+            --repo "$REPO" \
+            --pattern 'rust_template-*' \
+            --dir assets
+          rm -f assets/*.sig
+
+      - name: Attest build provenance
+        # v4.1.0
+        uses: >-
+          actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        with:
+          subject-path: assets/*

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -8,6 +8,13 @@ name: Docker
         description: "Push image to registry"
         type: boolean
         default: false
+    outputs:
+      image-digest:
+        description: >-
+          Manifest digest of the pushed image (sha256:...);
+          empty when push is false
+        value: >-
+          ${{ jobs.build-and-push.outputs.image-digest }}
   workflow_dispatch:
     inputs:
       push:
@@ -27,16 +34,15 @@ jobs:
   build-and-push:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
+    outputs:
+      image-digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout repository
         # v6.0.2
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
-      - name: Set up Docker Buildx
-        # v3.9.0
-        uses: >-
-          docker/setup-buildx-action@7c525be6cc8a882d5163ce04293cac18617c709f
-
+      # Login must precede Buildx setup so the BuildKit builder image
+      # is pulled with credentials, not anonymously.
       - name: Log in to Container Registry
         if: inputs.push
         # v3.4.0
@@ -46,6 +52,11 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        # v3.9.0
+        uses: >-
+          docker/setup-buildx-action@7c525be6cc8a882d5163ce04293cac18617c709f
 
       - name: Extract metadata
         id: meta
@@ -65,6 +76,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
+        id: build
         # v6.10.0
         uses: >-
           docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -101,6 +101,10 @@ jobs:
   snap:
     name: Build Snap Package
     runs-on: ubuntu-latest
+    env:
+      # The secrets context is not available in step `if:` expressions;
+      # expose the token via env so the publish step can gate on it.
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
     steps:
       - name: Checkout code
         # v6.0.2
@@ -130,13 +134,10 @@ jobs:
           gh release upload "$TAG" "$SNAP" --clobber
 
       - name: Publish to Snap Store
-        if: secrets.SNAPCRAFT_TOKEN != ''
+        if: env.SNAPCRAFT_STORE_CREDENTIALS != ''
         # v1.2.0
         uses: >-
           snapcore/action-publish@2f62f3ca778de25a88f1e29edb6ec4e763e53eef
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: >-
-            ${{ secrets.SNAPCRAFT_TOKEN }}
         with:
           snap: ${{ steps.build.outputs.snap }}
           release: stable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,11 +328,11 @@ mod property_tests {
 
 All CI and release work is orchestrated through a single `pipeline.yml` that calls reusable workflows via `workflow_call` with explicit `needs:` dependencies.
 
-**CI stage** (`ci-checks.yml`): fmt, clippy, test (Linux/macOS/Windows), doc build, cargo-deny, MSRV check (1.92), `all-checks-pass` gate. Runs in parallel with `ci-coverage.yml` (LCOV/Codecov) and `ci-test-matrix.yml` (12-combo matrix, PR only).
+**CI stage** (`ci-checks.yml`): fmt, clippy, test (Linux/macOS/Windows), doc build, cargo-deny, MSRV check (1.92), `all-checks-pass` gate. Runs in parallel with `ci-coverage.yml` (LCOV/Codecov), `ci-test-matrix.yml` (12-combo matrix, PR only), and `pin-check` (central `zircote/.github` workflow asserting every `uses:` is pinned to a full commit SHA).
 
-**Docker** (`release-docker.yml`): multi-platform build after CI passes. PR = build-only; push on main/tags.
+**Docker** (`release-docker.yml`): multi-platform build after CI passes. PR = build-only; push on main/tags. Pushed images flow through `docker-sign` (centralized `zircote/.github` `sign-and-attest.yml`, pinned by full SHA — under SLSA Build L3 the signing identity is the central workflow, not this repo) and `docker-verify` (fail-closed attestation verification).
 
-**Release stage** (tags only, after CI): `release-create.yml` (GH release + git-cliff + 5 binaries + CHANGELOG.md commit), then in parallel: `release-sign.yml` (Cosign + checksums), `release-publish.yml` (crates.io), `release-packages.yml` (Homebrew/Snap/MSI/deb/rpm), `release-sbom.yml` (SPDX), and SLSA provenance (inline jobs).
+**Release stage** (tags only, after CI + `docker-verify` — a tag publishes nothing unsigned): `release-create.yml` (GH release + git-cliff + 5 binaries + CHANGELOG.md commit), then in parallel: `release-sign.yml` (Cosign + checksums), `release-publish.yml` (crates.io), `release-packages.yml` (Homebrew/Snap/MSI/deb/rpm), `release-sbom.yml` (SPDX), and `slsa-binaries` (build provenance attested over the published release binaries; verify with `gh attestation verify <file> --repo zircote/rust-template`). Artifact verification commands live in `SECURITY.md` § Verifying Release Artifacts.
 
 See `docs/template/CI-WORKFLOWS.md` for the full reference.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,3 +49,61 @@ This project employs several security practices:
 - **Dependabot**: Automated dependency updates for security patches
 - **No unsafe code**: The crate forbids `unsafe` unless explicitly justified
 - **Minimal dependencies**: Only essential dependencies are included
+- **SHA-pinned actions**: Every GitHub Actions `uses:` reference is pinned to a full commit SHA, enforced by a `pin-check` CI gate
+- **Attested releases**: Container images are signed and attested (SLSA provenance, signature, SBOM, vulnerability report) by a centralized signer workflow and verified fail-closed before anything publishes
+
+## Verifying Release Artifacts
+
+Container images are signed and attested by the centralized signer workflow
+`zircote/.github/.github/workflows/sign-and-attest.yml` (SLSA Build L3:
+the signing identity is the central workflow, not this repository).
+Prerequisites: `gh` CLI authenticated, `cosign` installed.
+
+### Resolve the digest for a tag
+
+```bash
+DIGEST=$(gh api 'users/zircote/packages/container/rust-template/versions?per_page=20' \
+  --jq '[.[] | select((.metadata.container.tags // []) | index("<tag>"))][0].name')
+```
+
+### SLSA provenance
+
+`--repo` asserts where the build ran; `--signer-workflow` asserts the
+signing identity. Both are required — `--repo` alone fails by design.
+
+```bash
+gh attestation verify "oci://ghcr.io/zircote/rust-template@${DIGEST}" \
+  --repo zircote/rust-template \
+  --signer-workflow zircote/.github/.github/workflows/sign-and-attest.yml \
+  --predicate-type https://slsa.dev/provenance/v1
+```
+
+### Keyless signature
+
+```bash
+cosign verify "ghcr.io/zircote/rust-template@${DIGEST}" \
+  --certificate-identity-regexp '^https://github.com/zircote/\.github/\.github/workflows/sign-and-attest\.yml@.*$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+### SBOM and vulnerability report attestations
+
+```bash
+cosign verify-attestation "ghcr.io/zircote/rust-template@${DIGEST}" \
+  --type cyclonedx \
+  --certificate-identity-regexp '^https://github.com/zircote/\.github/\.github/workflows/sign-and-attest\.yml@.*$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+# Vulnerability report: same command with
+#   --type "https://in-toto.io/attestation/vulns/v0.1"
+```
+
+### Release binaries
+
+Binaries attached to a GitHub Release carry build provenance attested by
+this repository's own release workflow (no `--signer-workflow` needed):
+
+```bash
+gh release download <tag> --repo zircote/rust-template
+gh attestation verify rust_template-linux-amd64 --repo zircote/rust-template
+sha256sum --check SHA256SUMS
+```

--- a/crates/lib.rs
+++ b/crates/lib.rs
@@ -76,10 +76,12 @@ pub fn divide(dividend: i64, divisor: i64) -> Result<i64> {
         return Err(Error::InvalidInput("divisor cannot be zero".to_string()));
     }
 
-    dividend.checked_div(divisor).ok_or_else(|| Error::OperationFailed {
-        operation: "divide".to_string(),
-        cause: "overflow when dividing i64 values".to_string(),
-    })
+    dividend
+        .checked_div(divisor)
+        .ok_or_else(|| Error::OperationFailed {
+            operation: "divide".to_string(),
+            cause: "overflow when dividing i64 values".to_string(),
+        })
 }
 
 /// Parses `input` as a non-negative integer and returns it.

--- a/docs/template/CI-WORKFLOWS.md
+++ b/docs/template/CI-WORKFLOWS.md
@@ -15,20 +15,22 @@ before any release work begins and eliminates duplicate checks.
 ```text
                        push/PR/tag
                             |
-                  +---------+---------+
-                  |         |         |
-                [ci]   [coverage] [test-matrix]*
-                  |                   (* PR only)
-        +---------+---------+
-        |                   |
-     [docker]          [release]**
-   (PR=build-only)     (** tags only)
-                            |
-       +--------+--------+--+--------+--------+
-       |        |        |  |        |        |
-    [sign] [publish] [pkgs] [sbom] [slsa-build]
-                                        |
-                                  [slsa-provenance]
+            +---------+-----+-----+-------------+
+            |         |           |             |
+          [ci]   [coverage] [test-matrix]* [pin-check]
+            |                 (* PR only)
+         [docker]
+       (PR=build-only)
+            |
+      [docker-sign]       (push/tags only — central signer)
+            |
+     [docker-verify]      (fail-closed gate)
+            |
+        [release]**       (** tags only; needs ci + docker-verify)
+            |
+     +--------+--------+--------+----------+
+     |        |        |        |          |
+  [sign] [publish] [pkgs]   [sbom] [slsa-binaries]
 ```
 
 ---
@@ -46,9 +48,12 @@ before any release work begins and eliminates duplicate checks.
 | Create Release | `release-create.yml` | `pipeline.yml` (tags) | GH release, git-cliff body, 5 binaries, CHANGELOG.md |
 | Sign Release | `release-sign.yml` | `pipeline.yml` (tags) | Cosign signing, SHA256/SHA512 checksums |
 | Publish | `release-publish.yml` | `pipeline.yml` (tags) | cargo package + crates.io publish |
-| Docker | `release-docker.yml` | `pipeline.yml` | Multi-platform Docker build/push to GHCR |
+| Docker | `release-docker.yml` | `pipeline.yml` | Multi-platform Docker build/push to GHCR; outputs the manifest digest |
 | Packages | `release-packages.yml` | `pipeline.yml` (tags) | Homebrew, Snap, MSI, deb, rpm |
 | SBOM | `release-sbom.yml` | `pipeline.yml` (tags) | SPDX SBOM generation, attach to release |
+| Pin Check | `zircote/.github` » `pin-check.yml` | `pipeline.yml` | Asserts every `uses:` is pinned to a 40-char SHA |
+| Sign and Attest Image | `zircote/.github` » `sign-and-attest.yml` | `pipeline.yml` (push/tags) | Cosign signature, SLSA provenance, SBOM + vuln report as OCI referrers |
+| Verify Image Attestations | `zircote/.github` » `verify-attestation.yml` | `pipeline.yml` (push/tags) | Fail-closed verification gate before release |
 
 ### Standalone Workflows
 
@@ -100,11 +105,18 @@ tag runs.
 
 **Job dependency chain:**
 
-- `ci`, `coverage`, `test-matrix` — run in parallel (test-matrix is PR only)
+- `ci`, `coverage`, `test-matrix`, `pin-check` — run in parallel
+  (test-matrix is PR only)
 - `docker` — needs `ci` (PR = build-only via `push: false`)
-- `release` — needs `ci` (tags only)
-- `sign`, `publish`, `packages`, `sbom`, `slsa-build` — need `release`
-- `slsa-provenance` — needs `slsa-build`
+- `docker-sign` — needs `docker` (push/tags only); calls the centralized
+  `zircote/.github` signer workflow, pinned by full commit SHA (SLSA
+  Build L3 isolation — the signing identity is the central workflow,
+  not this repository)
+- `docker-verify` — needs `docker-sign`; fail-closed verification of
+  signature, provenance, and SBOM attestations
+- `release` — needs `ci` + `docker-verify` (tags only) — a tag publishes
+  nothing unsigned
+- `sign`, `publish`, `packages`, `sbom`, `slsa-binaries` — need `release`
 
 ---
 
@@ -178,6 +190,9 @@ linux/arm64) and optionally pushes to GHCR. Uses GitHub Actions cache for
 layer caching. Tags follow semver and include `latest` for the default branch.
 
 **Inputs:** `push` (boolean, default: false).
+
+**Outputs:** `image-digest` — the pushed manifest digest (`sha256:...`),
+consumed by the `docker-sign`/`docker-verify` attestation chain.
 
 ### release-packages.yml
 


### PR DESCRIPTION
## Summary

Onboards this repo to the attested delivery architecture (Mode A — consumer of the existing `zircote/.github` central workflows, pinned at `e8f0dbde068cc0701e443e7b8d57ae9917de7da3`).

**Invariant**: an artifact reaches consumers only if it is byte-identical to what was validated, carries attestations (SLSA provenance, signature, SBOM, vuln report) that re-verify, and publication is gated on fail-closed verification.

## Attested delivery changes

- **`release-docker.yml`** — emits the pushed manifest digest as a `workflow_call` output (`image-digest`); registry login reordered to precede Buildx setup so builder/base pulls are authenticated.
- **`pipeline.yml`**
  - `pin-check` job calling the central `pin-check.yml` — asserts every `uses:` is pinned to a full 40-char SHA. Check context: `pin-check / pin-check`, to become a required status check.
  - `docker-sign` — signs/attests pushed images via the centralized `sign-and-attest.yml` (SLSA Build L3: the signing identity is the central workflow, which this repo cannot modify).
  - `docker-verify` — fail-closed verification of signature + provenance + SBOM between signing and release.
  - `release` now needs `docker-verify` — **a tag publishes nothing unsigned**.
  - The tag-pinned `slsa-framework/slsa-github-generator@v2.1.0` rebuild jobs are replaced by `actions/attest-build-provenance` over the **published** release binaries (`slsa-binaries`). The old jobs attested a fresh rebuild (hashes need not match the released assets) and their tag pin would fail the pin-check gate (the generator refuses SHA refs by design).
- **`SECURITY.md`** — new "Verifying Release Artifacts" section: digest resolution, `gh attestation verify` with `--signer-workflow`, `cosign verify`, SBOM/vuln attestation verification, binary verification.
- **Docs** — `CI-WORKFLOWS.md` diagram/tables/dependency chain and the `CLAUDE.md` CI/CD section updated.

## Pre-existing CI defects fixed en route

Wiring the verify gate exposed that **every Pipeline run (PR and main push) has been startup-failing with zero jobs since at least April**:

1. **`release-packages.yml`**: `if: secrets.SNAPCRAFT_TOKEN != ''` — the `secrets` context is not available in `if:` expressions, making the file a compile error. Because `pipeline.yml` calls it locally, the whole caller graph failed at startup ("workflow file issue", 0 jobs) on every event, and branch pushes produced orphan failure runs attributed to `release-packages.yml`. Fixed by exposing the token via job-level `env` and gating on `env.SNAPCRAFT_STORE_CREDENTIALS`.
2. **`ci-coverage.yml`**: the percentage parser grepped `TOTAL <float>%`, which never matches cargo-llvm-cov's summary table (an integer region count follows `TOTAL`), so coverage always parsed as 0% and failed the 90% threshold. Now parsed from the JSON report via jq (locally measures 95.68%).
3. **`crates/lib.rs`**: rustfmt drift under current stable (chain formatting in `divide()`), which failed `CI Checks / Format` once CI could actually run.

## Dry-run / verification

The chain is exercisable without cutting a tag: `workflow_dispatch` → stage `docker` runs build → push → sign → verify on main. Independent workstation verification commands are in `SECURITY.md`.
