### PR TITLE
fix(ci): runnable docker-stage dispatch + fail-soft changelog commit

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -45,10 +45,13 @@ jobs:
   # -----------------------------------------------------------
   ci:
     name: CI Checks
+    # stage 'docker' includes ci so the docker -> sign -> verify
+    # chain is exercisable via dispatch (docker needs ci)
     if: >-
       github.event_name != 'workflow_dispatch'
       || inputs.stage == 'all'
       || inputs.stage == 'ci'
+      || inputs.stage == 'docker'
     uses: ./.github/workflows/ci-checks.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -99,9 +99,16 @@ jobs:
             ARGS+=(-f "sha=${SHA}")
           fi
 
-          gh api "$API_PATH" \
-            --method PUT "${ARGS[@]}"
-          echo "Changelog updated via GitHub API"
+          # main carries a ruleset requiring status checks; the
+          # GITHUB_TOKEN bot cannot bypass it, so a rejected push
+          # must not fail the release — the release body already
+          # carries the changelog content.
+          if gh api "$API_PATH" \
+            --method PUT "${ARGS[@]}"; then
+            echo "Changelog updated via GitHub API"
+          else
+            echo "::warning title=CHANGELOG.md not committed::Push to main was rejected (ruleset requires status checks). Release notes are unaffected. Update CHANGELOG.md via a PR or add a ruleset bypass actor."
+          fi
 
   build-binaries:
     name: Build ${{ matrix.target }}

--- a/docs/template/CI-WORKFLOWS.md
+++ b/docs/template/CI-WORKFLOWS.md
@@ -101,7 +101,9 @@ tag `v*.*.*`, manual (with stage selector).
 tag runs.
 
 **Manual dispatch stages:** `all`, `ci`, `release`, `sign`, `publish`,
-`docker`, `packages`, `sbom`, `slsa`.
+`docker`, `packages`, `sbom`, `slsa`. Stage `docker` also runs `ci`
+(a dependency), making the build → push → sign → verify chain
+exercisable without cutting a tag.
 
 **Job dependency chain:**
 


### PR DESCRIPTION
Follow-up to #78.

- Dispatch stage `docker` now also runs `ci` — `docker` needs `ci`, so the stage previously skipped every job, making the attested-chain dry-run impossible. With this, `workflow_dispatch -> stage=docker` exercises build → push → sign → verify without cutting a tag.
- The CHANGELOG commit to main during releases now warns instead of failing when the main ruleset (required status checks: `CI Checks / All Checks Pass`, `pin-check / pin-check`) rejects the bot push. The release body already carries the changelog content. Restoring auto-commit requires a bypass actor (deploy key or PAT) — left as an explicit owner decision.
