### PR TITLE
fix(ci): address PR #78-#80 review findings

### DIFF
--- a/.github/workflows/package-homebrew.yml
+++ b/.github/workflows/package-homebrew.yml
@@ -68,8 +68,10 @@ jobs:
           SRC_URL="${SRC_URL}/archive/refs/tags"
           SRC_URL="${SRC_URL}/v${VERSION}.tar.gz"
 
-          # Compute SHA256
-          SRC_SHA=$(curl -sL "$SRC_URL" \
+          # Compute SHA256 — fail loudly on any download error so the
+          # formula can never carry a hash of an error response.
+          set -euo pipefail
+          SRC_SHA=$(curl -fsSL "$SRC_URL" \
             | shasum -a 256 | awk '{print $1}')
 
           echo "src_url=$SRC_URL" >> "$GITHUB_OUTPUT"
@@ -81,6 +83,13 @@ jobs:
         with:
           ref: v${{ steps.release.outputs.version }}
           path: project
+
+      - name: Install Rust toolchain
+        # master
+        uses: >-
+          dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
 
       - name: Resolve project metadata from Cargo.toml
         id: meta
@@ -107,7 +116,10 @@ jobs:
             echo "class=${CLASS}"
           } >> "$GITHUB_OUTPUT"
 
+      # Dry-runs never touch the tap repo, so previewing a formula
+      # requires neither HOMEBREW_TAP_TOKEN nor an existing tap.
       - name: Checkout homebrew tap
+        if: github.event.inputs.dry_run != 'true'
         # v6.0.3
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
@@ -129,8 +141,8 @@ jobs:
           FORMULA: ${{ steps.meta.outputs.formula }}
           CLASS: ${{ steps.meta.outputs.class }}
         run: |
-          mkdir -p homebrew-tap/Formula
-          cat > "homebrew-tap/Formula/${FORMULA}.rb" << FORMULA_EOF
+          mkdir -p formula-out
+          cat > "formula-out/${FORMULA}.rb" << FORMULA_EOF
           class ${CLASS} < Formula
             desc "${DESC}"
             homepage "https://github.com/${REPO}"
@@ -155,11 +167,13 @@ jobs:
 
       - name: Commit and push formula
         if: github.event.inputs.dry_run != 'true'
-        working-directory: homebrew-tap
         env:
           VERSION: ${{ steps.release.outputs.version }}
           FORMULA: ${{ steps.meta.outputs.formula }}
         run: |
+          mkdir -p homebrew-tap/Formula
+          cp "formula-out/${FORMULA}.rb" "homebrew-tap/Formula/"
+          cd homebrew-tap
           git config user.name "github-actions[bot]"
           git config user.email \
             "github-actions[bot]@users.noreply.github.com"
@@ -180,4 +194,4 @@ jobs:
           FORMULA: ${{ steps.meta.outputs.formula }}
         run: |
           echo "=== ${FORMULA}.rb (source) ==="
-          cat "homebrew-tap/Formula/${FORMULA}.rb"
+          cat "formula-out/${FORMULA}.rb"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,20 @@ jobs:
             | jq -r '.packages[0].name')
           echo "name=${NAME}" >> "$GITHUB_OUTPUT"
 
+      # cargo publish ships the Cargo.toml version regardless of the tag;
+      # publishing is irreversible, so a mismatch must fail before publish.
+      - name: Assert tag version matches Cargo.toml
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          CARGO_VERSION=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[0].version')
+          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "::error::tag v${TAG_VERSION} does not match" \
+              "Cargo.toml version ${CARGO_VERSION}"
+            exit 1
+          fi
+
       - name: Verify package
         run: |
           cargo package --list
@@ -68,9 +82,9 @@ jobs:
       - name: Run pre-publish checks
         run: |
           cargo fmt -- --check
-          cargo clippy --all-targets --all-features -- -D warnings
-          cargo test --all-features
-          cargo doc --no-deps --all-features
+          cargo clippy --all-targets --all-features --locked -- -D warnings
+          cargo test --all-features --locked
+          cargo doc --no-deps --all-features --locked
           cargo deny check
 
       - name: Dry run publish
@@ -105,8 +119,10 @@ jobs:
           CRATE="${NAME}-${VERSION}.crate"
           URL="https://static.crates.io/crates/${NAME}/${CRATE}"
           downloaded=0
+          # static.crates.io can reject requests without a User-Agent
           for attempt in 1 2 3 4 5 6; do
-            if curl -fsSL -o "${CRATE}" "$URL"; then
+            if curl -fsSL -A "${NAME}-release-check" \
+              -o "${CRATE}" "$URL"; then
               downloaded=1
               break
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,13 @@ jobs:
         # v6.0.3
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
+      - name: Install Rust toolchain
+        # master
+        uses: >-
+          dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
+
       - name: Resolve binary name and version from Cargo.toml
         id: meta
         run: |
@@ -310,7 +317,7 @@ jobs:
         uses: >-
           softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
-          tag_name: ${{ github.ref }}
+          tag_name: ${{ github.ref_name }}
           name: Release ${{ needs.meta.outputs.version }}
           generate_release_notes: true
           draft: false

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,7 +62,7 @@ Prerequisites: `gh` CLI authenticated, `cosign` installed.
 ### Resolve the digest for a tag
 
 ```bash
-DIGEST=$(gh api 'users/zircote/packages/container/rust-template/versions?per_page=20' \
+DIGEST=$(gh api 'users/zircote/packages/container/rust-template/versions?per_page=100' \
   --jq '[.[] | select((.metadata.container.tags // []) | index("<tag>"))][0].name')
 ```
 


### PR DESCRIPTION
Remediates all open review comments from the merged PRs #78, #79, #80 (merged prematurely — process corrected going forward: reviews complete + comments addressed before merge).

## Accepted findings fixed here

| Finding (PR) | Fix |
|---|---|
| publish can ship a Cargo.toml/tag version mismatch — irreversible (#80) | New tag-gated assert step fails before `cargo publish` on mismatch |
| pre-publish checks not `--locked` (#80) | `--locked` on clippy/test/doc |
| crate download lacks User-Agent (#80) | `-A '<name>-release-check'` |
| formula SHA can hash an error response (#80, 2 comments) | `set -euo pipefail` + `curl -fsSL` |
| `tag_name: github.ref` is the full ref (#80) | `github.ref_name` |
| `cargo metadata` without toolchain install (#80, 2 comments) | `dtolnay/rust-toolchain@stable` in `meta` and homebrew jobs |
| dry-run requires tap token (#80) | Formula generated in workspace; tap checkout/push skipped on dry-run |
| SECURITY.md digest lookup per_page=20 misses old tags (#78) | per_page=100 |

## Refuted / moot (replied on the original threads)

- Hyphenated output dot-notation claims (#78, 3 comments): GitHub property dereference explicitly permits `-`; empirically proven by the green sign/verify chain on main (run 27375531100) which consumed `needs.docker.outputs.image-digest`.
- release-create.yml error-handling (#79): file deleted in #80; the new architecture has no changelog-commit step.