### PR TITLE
fix(ci): --locked on every cargo metadata call in release workflows

### DIFF
--- a/.github/workflows/package-homebrew.yml
+++ b/.github/workflows/package-homebrew.yml
@@ -98,7 +98,7 @@ jobs:
         working-directory: project
         run: |
           set -euo pipefail
-          META=$(cargo metadata --no-deps --format-version 1)
+          META=$(cargo metadata --no-deps --locked --format-version 1)
           BIN=$(jq -r \
             '[.packages[0].targets[] | select(.kind | index("bin"))][0].name' \
             <<< "$META")

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Read package.publish from Cargo.toml
         id: gate
         run: |
-          PUBLISHABLE=$(cargo metadata --no-deps --format-version 1 \
+          PUBLISHABLE=$(cargo metadata --no-deps --locked --format-version 1 \
             | jq -r \
             'if .packages[0].publish == [] then "false" else "true" end')
           echo "publishable=${PUBLISHABLE}" >> "$GITHUB_OUTPUT"
@@ -87,7 +87,7 @@ jobs:
       - name: Resolve crate name
         id: crate-meta
         run: |
-          NAME=$(cargo metadata --no-deps --format-version 1 \
+          NAME=$(cargo metadata --no-deps --locked --format-version 1 \
             | jq -r '.packages[0].name')
           echo "name=${NAME}" >> "$GITHUB_OUTPUT"
 
@@ -97,7 +97,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
-          CARGO_VERSION=$(cargo metadata --no-deps --format-version 1 \
+          CARGO_VERSION=$(cargo metadata --no-deps --locked --format-version 1 \
             | jq -r '.packages[0].version')
           if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
             echo "::error::tag v${TAG_VERSION} does not match" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         id: meta
         run: |
           set -euo pipefail
-          META=$(cargo metadata --no-deps --format-version 1)
+          META=$(cargo metadata --no-deps --locked --format-version 1)
           BIN=$(jq -r \
             '[.packages[0].targets[] | select(.kind | index("bin"))][0].name' \
             <<< "$META")


### PR DESCRIPTION
Applies the Copilot finding from zircote/rlm-rs#255 to this repo's five `cargo metadata` call sites (publish guard/crate-meta/version-assert, release meta, homebrew meta): without `--locked`, metadata resolution can rewrite Cargo.lock during a release run. Release-run reads must fail on a stale lockfile, never mutate it.