### PR TITLE
fix(ci): sticky PR report comments (coverage/benchmark/mutation)

### DIFF
--- a/.github/workflows/benchmark-regression.yml
+++ b/.github/workflows/benchmark-regression.yml
@@ -116,13 +116,29 @@ jobs:
           script: |
             const fs = require('fs');
             if (fs.existsSync('benchmark-report.md')) {
-              const report = fs.readFileSync('benchmark-report.md', 'utf8');
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: report
-              });
+              // Sticky comment: update one report in place per PR.
+              const marker = '<!-- sticky-report: benchmark -->';
+              const body = marker + '\n'
+                + fs.readFileSync('benchmark-report.md', 'utf8');
+              const { owner, repo } = context.repo;
+              const issue_number = context.issue.number;
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number, per_page: 100 }
+              );
+              const existing = comments.find(
+                (c) => c.user.type === 'Bot'
+                  && c.body && c.body.includes(marker)
+              );
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: existing.id, body
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number, body
+                });
+              }
             }
 
       - name: Save baseline for main branch

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -123,16 +123,31 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const report = fs.readFileSync(
+            // Sticky comment: update one report in place instead of posting a
+            // new comment on every run.
+            const marker = '<!-- sticky-report: coverage -->';
+            const body = marker + '\n' + fs.readFileSync(
               'coverage-report.md', 'utf8'
             );
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: report
-            });
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 }
+            );
+            const existing = comments.find(
+              (c) => c.user.type === 'Bot'
+                && c.body && c.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body
+              });
+            }
 
       - name: Check coverage threshold
         env:

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -100,11 +100,27 @@ jobs:
           script: |
             const fs = require('fs');
             if (fs.existsSync('mutation-report.md')) {
-              const report = fs.readFileSync('mutation-report.md', 'utf8');
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: report
-              });
+              // Sticky comment: update one report in place per PR.
+              const marker = '<!-- sticky-report: mutation -->';
+              const body = marker + '\n'
+                + fs.readFileSync('mutation-report.md', 'utf8');
+              const { owner, repo } = context.repo;
+              const issue_number = context.issue.number;
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number, per_page: 100 }
+              );
+              const existing = comments.find(
+                (c) => c.user.type === 'Bot'
+                  && c.body && c.body.includes(marker)
+              );
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: existing.id, body
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number, body
+                });
+              }
             }


### PR DESCRIPTION
The coverage, benchmark, and mutation-testing workflows posted a **new** PR comment every run (`issues.createComment`), flooding PRs with duplicate reports (PR #91 accumulated ~9 each). Each now does a sticky upsert — find the existing bot comment by a hidden marker (`<!-- sticky-report: ... -->`) and `updateComment` in place, else create once. No new permissions needed (these jobs already commented).