### PR TITLE
docs+feat: world-class template — Diátaxis overhaul, tutorial, examples, benches

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,6 +1,11 @@
 ---
 name: Deploy Documentation
 
+# Builds and validates the docs site (rustdoc + Astro) on every relevant change
+# so breakage is caught early. Publishing to GitHub Pages is OPT-IN and dormant
+# in the template: enable Pages (Settings -> Pages -> "GitHub Actions") and set
+# the repo variable DEPLOY_DOCS=true to deploy. See the Setup Pages step below.
+
 "on":
   push:
     branches: [main]
@@ -67,16 +72,19 @@ jobs:
           REDIR="$REDIR"' content="0; url=rust_template">'
           echo "$REDIR" > site/dist/api/index.html
 
+      # Pages deploy is OPT-IN. The template builds and validates the docs on
+      # every change (above), but does not publish by default: a fresh template
+      # has no GitHub Pages site, and this org does not allow the Actions token
+      # to create one (configure-pages enablement fails "Resource not accessible
+      # by integration"). To publish, enable Pages (Settings -> Pages ->
+      # "GitHub Actions") and set the repo variable DEPLOY_DOCS=true.
       - name: Setup Pages
+        if: vars.DEPLOY_DOCS == 'true'
         # yamllint disable-line rule:line-length
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
-        with:
-          # Self-bootstrap: enable GitHub Pages (build_type: workflow) on first
-          # run so the template — and any downstream fork — deploys docs without
-          # manual repo setup.
-          enablement: true
 
       - name: Upload artifact
+        if: vars.DEPLOY_DOCS == 'true'
         # yamllint disable-line rule:line-length
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
@@ -84,6 +92,7 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
+    if: vars.DEPLOY_DOCS == 'true'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -3,7 +3,8 @@ name: Mutation Testing
 on:
   pull_request:
     paths:
-      - 'src/**'
+      # Source lives in crates/ (not src/) — see ADR-0002.
+      - 'crates/**'
       - 'tests/**'
       - 'Cargo.toml'
       - 'Cargo.lock'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,36 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,10 +60,123 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "errno"
@@ -50,6 +193,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -70,6 +219,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +255,12 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "memchr"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "num-traits"
@@ -95,6 +276,22 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -193,6 +390,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +422,7 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 name = "rust_template"
 version = "0.1.1"
 dependencies = [
+ "criterion",
  "proptest",
  "test-case",
  "thiserror",
@@ -231,6 +452,64 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "syn"
@@ -310,6 +589,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +620,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +637,37 @@ checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -379,3 +709,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ path = "crates/lib.rs"
 name = "rust_template"
 path = "crates/main.rs"
 
+[[bench]]
+name = "benchmarks"
+harness = false
+
 [dependencies]
 # Core dependencies
 thiserror = "2.0.18"
@@ -46,6 +50,10 @@ thiserror = "2.0.18"
 # Testing
 proptest = "1.11.0"
 test-case = "3.3.1"
+
+# Benchmarking (criterion; default features off to keep the dep tree lean
+# and supply-chain surface small — see benches/benchmarks.rs)
+criterion = { version = "0.8.2", default-features = false }
 
 # Async testing (uncomment if using tokio)
 # tokio-test = "0.4"

--- a/README.md
+++ b/README.md
@@ -66,24 +66,33 @@ fn main() -> Result<(), rust_template::Error> {
 
 ## API Overview
 
+> **This is placeholder example API.** `add`, `divide`, `process`, `Config`, and
+> `Error` exist only to demonstrate the template's conventions — error handling,
+> consuming-self builders, doc comments, and tests. **Replace them with your
+> crate's real surface** (the [first-project tutorial](docs/tutorials/first-project.md)
+> walks through doing exactly that).
+
 ### Functions
 
 | Function | Description |
 |----------|-------------|
-| `add(a, b)` | Adds two numbers |
-| `divide(a, b)` | Divides with error handling |
+| `add(a, b)` | Adds two numbers (pure, `const fn`) |
+| `divide(a, b)` | Divides, returning `Result` for divide-by-zero |
+| `process(input)` | Parses and validates a `&str` into an `i64` |
 
 ### Types
 
 | Type | Description |
 |------|-------------|
-| `Config` | Configuration with builder pattern |
-| `Error` | Error type for operations |
+| `Config` | Configuration with a consuming-self builder |
+| `Error` | Error type (`thiserror`) for operations |
 | `Result<T>` | Type alias for `Result<T, Error>` |
 
 ## Getting Started
 
-**New to this template?** See the [Getting Started Guide](docs/template/GETTING-STARTED.md) for a step-by-step walkthrough from "Use this template" to your first CI pass.
+**Brand new?** Follow the [**Your First Project** tutorial](docs/tutorials/first-project.md) — a guided, learning-oriented walkthrough from "Use this template" to a green build, your first change, and your first release.
+
+For task-focused steps, see the [Getting Started Guide](docs/template/GETTING-STARTED.md).
 
 ## Development
 
@@ -211,22 +220,9 @@ This template includes production-ready workflows:
 
 ### Creating a Release
 
-Releases are orchestrated end-to-end by the `/release` skill (`.claude/skills/release/SKILL.md`). The manual equivalent:
+Releases are orchestrated end-to-end by the `/release` skill (`.claude/skills/release/SKILL.md`). The full procedure, gates, and timings live in the canonical [Releasing runbook](docs/runbooks/RELEASING.md); the design rationale is in [Signed Releases](docs/security/SIGNED-RELEASES.md).
 
-1. Update version in `Cargo.toml`
-2. Create and push a version tag:
-   ```bash
-   git tag -a v0.2.0 -m "Release v0.2.0"
-   git push origin v0.2.0
-   ```
-3. Workflows automatically:
-   - Build binaries for all platforms with SLSA build provenance
-   - Generate and attest a `CycloneDX` SBOM
-   - Verify every attestation (fail-closed) before publishing anything
-   - Create GitHub release with artifacts and checksums
-   - Build, sign, and push Docker images
-   - Publish to crates.io via Trusted Publishing
-   - Update the Homebrew tap formula
+In short: bump the version in `Cargo.toml`, push a `vX.Y.Z` tag, and the workflows build all platform binaries with SLSA provenance, generate + attest a `CycloneDX` SBOM, fail-closed-verify every attestation, then create the GitHub release, sign/push images, publish to crates.io (Trusted Publishing), and update the Homebrew tap.
 
 Verification commands for every artifact type live in [SECURITY.md](SECURITY.md#verifying-release-artifacts).
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,0 +1,22 @@
+//! Criterion micro-benchmarks for the `rust_template` example API.
+//!
+//! Run with `cargo bench` (or `just bench`). Results land in
+//! `target/criterion/`; CI archives them and `benchmark-regression.yml`
+//! compares them against the `main` baseline.
+//!
+//! NOTE: these benchmark the placeholder `add` / `divide` / `process`
+//! functions — replace them when you replace the example API.
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use rust_template::{add, divide, process};
+
+fn benchmarks(c: &mut Criterion) {
+    c.bench_function("add", |b| b.iter(|| add(black_box(2), black_box(40))));
+    c.bench_function("divide", |b| b.iter(|| divide(black_box(84), black_box(2))));
+    c.bench_function("process", |b| b.iter(|| process(black_box("42"))));
+}
+
+criterion_group!(benches, benchmarks);
+criterion_main!(benches);

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # Deployment Guide
 
 This document provides comprehensive deployment instructions for the rust-template project.
@@ -109,7 +112,7 @@ chmod +x rust_template-0.1.0-linux-amd64
 ./rust_template-0.1.0-linux-amd64 --version
 ```
 
-Full verification commands (provenance, SBOM, checksums, container images, crate) are in [SECURITY.md](../SECURITY.md#verifying-release-artifacts).
+Full verification commands (provenance, SBOM, checksums, container images, crate) are in [SECURITY.md](../SECURITY.md#verifying-release-artifacts). For *why* releases are attested and how the attestation chain is structured, see [Signed Releases & SLSA Provenance](security/SIGNED-RELEASES.md).
 
 ### Docker (GitHub Container Registry)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Documentation Index
 
 > All documentation for the rust_template project.
@@ -83,6 +86,14 @@ Detailed reference material organized by topic.
 | Document | Description |
 |----------|-------------|
 | [Deployment Guide](DEPLOYMENT.md) | Comprehensive deployment instructions |
+
+### Explanation
+
+Design rationale and trade-offs — the "why" behind the template.
+
+| Document | Description |
+|----------|-------------|
+| [Template Architecture](explanation/architecture.md) | Why `crates/` not `src/`, the CI orchestration model, the `publish = false` gate, attested delivery, lint philosophy, and library conventions |
 
 ## Architectural Decision Records
 

--- a/docs/adr/0001-use-architectural-decision-records.md
+++ b/docs/adr/0001-use-architectural-decision-records.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: explanation
+---
 # Use Architectural Decision Records
 
 ## Status

--- a/docs/adr/0002-documentation-directory-structure.md
+++ b/docs/adr/0002-documentation-directory-structure.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: explanation
+---
 # Documentation Directory Structure
 
 ## Status

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # Architectural Decision Records
 
 This directory contains Architectural Decision Records (ADRs) for the `rust_template` project.

--- a/docs/distribution/ALTERNATIVE-REGISTRIES.md
+++ b/docs/distribution/ALTERNATIVE-REGISTRIES.md
@@ -1,10 +1,15 @@
+---
+diataxis_type: reference
+---
 # Alternative Cargo Registries
 
 ## Overview
 
 Publishing Rust crates to alternative registries beyond crates.io for private packages, enterprise distribution, or specialized ecosystems.
 
-## Why Alternative Registries?
+## Why Alternative Registries? (explanation)
+
+> This section is rationale; the registry catalog and configuration tables below are the reference content.
 
 - **Private packages** - Keep proprietary code internal
 - **Enterprise control** - Host on internal infrastructure

--- a/docs/distribution/DOCKER-REGISTRIES.md
+++ b/docs/distribution/DOCKER-REGISTRIES.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Docker Multi-Registry Distribution
 
 ## Overview
@@ -275,7 +278,9 @@ Add provenance and SBOM:
 - **Lifecycle policies** - Auto-delete old images
 - **IAM integration** - AWS permissions
 
-## Security Best Practices
+## Security Best Practices (how-to)
+
+> The registry list, tagging, and metadata sections above are reference; this section and the troubleshooting snippets below are task-oriented guidance.
 
 ### 1. Use Specific Tags
 

--- a/docs/distribution/PACKAGE-MANAGERS.md
+++ b/docs/distribution/PACKAGE-MANAGERS.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # Package Manager Distribution
 
 ## Overview

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,0 +1,177 @@
+---
+diataxis_type: explanation
+---
+# Template Architecture & Design Rationale
+
+This document explains *why* `rust_template` is built the way it is. It is the
+single place to understand the design trade-offs behind the source layout, the
+CI orchestration model, the supply-chain story, and the library conventions. It
+deliberately contains no step-by-step instructions — for those, follow the
+how-to guides linked throughout.
+
+For the formal, dated decisions behind two of these choices, see the
+[Architectural Decision Records](../adr/README.md): in particular
+[ADR-0001 (use ADRs)](../adr/0001-use-architectural-decision-records.md) and
+[ADR-0002 (documentation directory structure)](../adr/0002-documentation-directory-structure.md).
+
+## Why `crates/` instead of `src/`
+
+The library root is `crates/lib.rs` and the binary entry point is
+`crates/main.rs`, wired up explicitly through the `[lib]` and `[[bin]]` `path`
+keys in `Cargo.toml`. This is a deliberate departure from the conventional
+`src/` layout.
+
+The reason is that this is a *template*, not an ordinary crate. Using `crates/`
+signals at a glance that the directory holds example scaffolding meant to be
+restructured, not production code to be preserved verbatim. A developer who
+clicks "Use this template" sees an unfamiliar path and is nudged to make a
+conscious decision about structure, rather than inheriting a layout by inertia.
+
+The trade-off is real but small: some tooling and muscle memory assume `src/`,
+so the `path` keys must be set explicitly and downstream projects that prefer
+the convention have one rename to perform. We accept that friction because the
+"this is scaffolding" signal is worth more in a template than convention
+adherence is.
+
+## The CI orchestration model
+
+CI is a single orchestrator, `pipeline.yml`, that calls focused reusable
+workflows rather than one monolithic file. The trade-off is intentional: a thin
+orchestrator with named child workflows is easier to reason about, reuse, and
+pin than a single file with dozens of inlined jobs.
+
+`pipeline.yml` runs on every push, pull request, and tag, and coordinates these
+jobs:
+
+- `gate` — resolves a single boolean, `publishable`, from `cargo metadata`. This
+  is the publish gate described below, and every publication-bearing job depends
+  on it.
+- `ci` — calls `ci-checks.yml` (fmt, clippy, multi-OS test, doc build,
+  cargo-deny, MSRV check, and an `all-checks-pass` aggregator).
+- `coverage` — calls `ci-coverage.yml` (LCOV to Codecov), in parallel with `ci`.
+- `test-matrix` — calls `ci-test-matrix.yml` (the broad feature/version matrix),
+  on pull requests.
+- `pin-check` — calls the central `zircote/.github` workflow that asserts every
+  `uses:` reference is pinned to a full 40-character commit SHA.
+- `docker` → `docker-sign` → `docker-verify`, plus `gate-image` and
+  `attest-container-scan` — the container build, sign, and fail-closed verify
+  chain.
+
+Releases are deliberately **not** part of this orchestrator. Tag-triggered
+publication runs through flat, independent workflows — `release.yml`,
+`publish.yml`, and `package-homebrew.yml` — each triggered by a tag (or a
+dispatch dry-run) and owning one channel. The rationale is blast-radius
+isolation: a failure in the Homebrew step must not be entangled with the
+crates.io publish or the GitHub Release. Flat, single-purpose release workflows
+fail independently and are re-runnable in isolation. This mirrors the verified
+reference architecture in `zircote/rlm-rs`.
+
+A second design rule keeps the template instantiable with almost no edits:
+**project specificity is var-driven.** The release workflows resolve the crate
+name, binary name, version, description, and license from `cargo metadata` at
+runtime, and the owner/repo from the GitHub context. Nothing in the workflow
+files is renamed when you adopt the template — you edit `Cargo.toml` and,
+optionally, one repository variable. Hard-coding those values into the workflows
+would have been simpler to write but would have turned every template adoption
+into a find-and-replace chore and a source of drift.
+
+## The `publish = false` gate pattern
+
+A template should ship *no* published artifacts — no container on a registry, no
+crate on crates.io, no GitHub Release, no Homebrew formula. But the same
+workflows that must stay dormant in template state must arm themselves the
+moment a real project adopts them. The mechanism that achieves both from a
+single switch is the `publish = false` line in `Cargo.toml`.
+
+`cargo` itself refuses `cargo publish` while that line is present. The workflows
+read the same fact independently: the `gate` job runs `cargo metadata` and
+resolves `publishable=false` when `.publish == []`. While `publishable` is
+false, the Docker build → sign → verify chain is **skipped** (not built and
+discarded — a template ships no container), and the crates.io, GitHub Release,
+and Homebrew channels are all gated off.
+
+Deleting that one line in a downstream project flips `publishable` to true and
+arms all four channels at once. The trade-off is that the gate is a single point
+of control — a downstream project that wants, say, container images but not
+crates.io must add finer-grained conditions. We accept that, because the
+overwhelmingly common need is "off in the template, all-on in real projects,"
+and one line serving that case beats four independent toggles a new adopter
+would have to discover.
+
+## Attested delivery, conceptually
+
+The guiding principle of the release machinery is **nothing publishes
+unverified**. Every release artifact carries cryptographic attestations, and a
+fail-closed verification job runs *before* the artifact becomes visible — the
+GitHub Release does not exist until verification passes.
+
+Three kinds of evidence are attached:
+
+- **SLSA provenance** — binds each artifact to the exact commit, workflow, and
+  run that produced it, signed keyless through Sigstore (no private keys to
+  manage or rotate).
+- **SBOM** — a CycloneDX Software Bill of Materials, generated and attested over
+  every binary, so consumers can audit the dependency set behind a release.
+- **Gate attestations** — for container images, the central
+  `zircote/.github` signer workflow attests under SLSA Build L3, which means the
+  signing identity is the *central* workflow, not this repository. Verification
+  therefore asserts both where the build ran and who signed.
+
+The non-negotiable property is **fail-closed verification**: a tag that produces
+an artifact failing verification publishes nothing. In-pipeline success is
+necessary but not sufficient; consumers are expected to verify on their side
+too. This is a conceptual overview — for the full attestation chain, who signs
+what, and the keyless-signing rationale, see
+[Signed Releases & SLSA Provenance](../security/SIGNED-RELEASES.md). The
+copy-paste verification commands live in
+[SECURITY.md](../../SECURITY.md#verifying-release-artifacts).
+
+## The lint philosophy: pedantic by default
+
+Clippy runs with the `pedantic`, `nursery`, and `cargo` lint groups enabled, and
+a strict deny list turns several patterns into hard errors: `unwrap_used`,
+`expect_used`, `panic`, `todo`, `unimplemented`, `dbg_macro`, and the print
+macros. `unsafe` code is forbidden outright.
+
+The rationale is that a template sets the ceiling for the projects built from it.
+Strictness is far cheaper to relax than to retrofit: a downstream project that
+finds pedantic lints noisy can downgrade specific lints in minutes, whereas a
+project that started permissive and later wants rigor faces a large remediation.
+Denying `unwrap_used` and `panic` in particular forces library code to handle
+errors explicitly and push failures to the API boundary, where callers — not the
+library — decide what to do. Test code is exempt from these denials (via
+`clippy.toml`), because the cost/benefit inverts in tests, where `unwrap` is
+legible and the blast radius is contained.
+
+## Why `thiserror` and consuming-self builders
+
+Two library conventions in `crates/lib.rs` are worth their own rationale.
+
+**`thiserror` for the error type.** The crate's `Error` enum derives
+`thiserror::Error`, and a crate-level alias `Result<T>` reduces boilerplate
+across the API. `thiserror` generates the `Display` and `From` implementations
+from attributes at zero runtime cost, keeping error definitions concise and
+consistent. The alternative — hand-writing `std::error::Error` impls, or
+reaching for a dynamic-error crate like `anyhow` — is either more boilerplate or
+less precise. `anyhow` suits applications that only need to report errors;
+`thiserror` suits a *library* that wants callers to be able to match on
+structured variants. This template is library-first, so `thiserror` is the
+right default.
+
+**Consuming-self builders.** `Config` uses builder methods shaped
+`fn with_field(mut self, value: T) -> Self` rather than `&mut self`. Three
+benefits follow. First, `const` evaluation: a `const fn` is compatible with owned
+`self` but not with `&mut self`, so the consuming form lets the entire builder be
+`const`. Second, chaining reads naturally —
+`Config::new().with_a(1).with_b(2)`. Third, move semantics avoid hidden shared
+state, since the builder is consumed at each step. The cost is that the builder
+cannot be reused after a method call without cloning, but configuration builders
+are almost always used once, so that cost rarely bites.
+
+## Related reading
+
+- [ADR-0001 — Use Architectural Decision Records](../adr/0001-use-architectural-decision-records.md)
+- [ADR-0002 — Documentation Directory Structure](../adr/0002-documentation-directory-structure.md)
+- [Signed Releases & SLSA Provenance](../security/SIGNED-RELEASES.md) — the attestation chain in depth
+- [Deployment Guide](../DEPLOYMENT.md) — how to actually cut a release
+- The project `CLAUDE.md` Reference and Explanation sections — the authoritative source for lint tables, cargo profiles, and conventions

--- a/docs/observability/METRICS-DASHBOARD.md
+++ b/docs/observability/METRICS-DASHBOARD.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Metrics & Observability Dashboard
 
 ## Overview
@@ -85,7 +88,9 @@ gh api repos/USER/REPO/actions/workflows/ci.yml/runs \
   --jq '.workflow_runs[] | {created_at, conclusion, run_duration_ms}'
 ```
 
-## Dashboard Options
+## Dashboard Options (how-to)
+
+> "Available Metrics" above is the reference catalog of metric sources; the options below are task-oriented setup recipes for surfacing them.
 
 ### Option 1: shields.io Badges
 

--- a/docs/runbooks/CI-TROUBLESHOOTING.md
+++ b/docs/runbooks/CI-TROUBLESHOOTING.md
@@ -1,3 +1,7 @@
+---
+diataxis_type: how-to
+---
+
 # CI Troubleshooting
 
 Common CI failure patterns and fixes for rust-template. Use this runbook when a workflow fails on a pull request or push to `main`.

--- a/docs/runbooks/DEPENDENCY-UPDATES.md
+++ b/docs/runbooks/DEPENDENCY-UPDATES.md
@@ -1,3 +1,7 @@
+---
+diataxis_type: how-to
+---
+
 # Dependency Updates
 
 Runbook for managing Cargo and GitHub Actions dependencies in rust-template.

--- a/docs/runbooks/RELEASING.md
+++ b/docs/runbooks/RELEASING.md
@@ -1,3 +1,7 @@
+---
+diataxis_type: how-to
+---
+
 # Releasing
 
 End-to-end runbook for creating, monitoring, and rolling back releases of rust-template.

--- a/docs/runbooks/SECURITY-RESPONSE.md
+++ b/docs/runbooks/SECURITY-RESPONSE.md
@@ -1,3 +1,7 @@
+---
+diataxis_type: how-to
+---
+
 # Security Incident Response
 
 Runbook for handling security vulnerabilities in rust-template. Based on the project's [Security Policy](../../SECURITY.md).

--- a/docs/security/SIGNED-RELEASES.md
+++ b/docs/security/SIGNED-RELEASES.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: explanation
+---
 # Signed Releases & SLSA Provenance
 
 ## Overview

--- a/docs/template/CI-WORKFLOWS.md
+++ b/docs/template/CI-WORKFLOWS.md
@@ -1,3 +1,7 @@
+---
+diataxis_type: reference
+---
+
 # CI/CD Workflows Reference
 
 Comprehensive guide to every GitHub Actions workflow included in the

--- a/docs/template/CONFIGURATION.md
+++ b/docs/template/CONFIGURATION.md
@@ -1,3 +1,7 @@
+---
+diataxis_type: how-to
+---
+
 # Template Configuration Guide
 
 > How to configure your new repository after creating it from the rust-template.

--- a/docs/template/COPILOT-JUMPSTART.md
+++ b/docs/template/COPILOT-JUMPSTART.md
@@ -1,3 +1,7 @@
+---
+diataxis_type: how-to
+---
+
 # Jumpstart Your Project with Copilot
 
 When you create a new repository from this template, GitHub offers an optional **"Jumpstart your project with Copilot"** prompt. Paste one of the prompts below into that field, and Copilot will open a pull request that scaffolds your project.

--- a/docs/template/CUSTOMIZATION.md
+++ b/docs/template/CUSTOMIZATION.md
@@ -1,3 +1,7 @@
+---
+diataxis_type: how-to
+---
+
 # Customization Guide
 
 This guide covers how to customize the `rust-template` beyond the initial setup. For basic configuration (renaming the crate, updating metadata), see the main README.
@@ -336,7 +340,9 @@ To relax any of these, change `"deny"` to `"warn"` or `"allow"`:
 todo = "warn"            # Allow TODOs with a warning
 ```
 
-Note that `print_stdout` and `print_stderr` are already allowed in `crates/main.rs` via file-level attributes. This is intentional -- binary entry points typically need to print output.
+Note that `print_stdout` and `print_stderr` are already allowed in `crates/main.rs` via file-level attributes.
+
+> **Why the binary exempts the print lints:** binary entry points typically need to write output to stdout/stderr, so the file-level `#[allow]` in `crates/main.rs` is intentional. Library code stays subject to the deny.
 
 ### `clippy.toml` thresholds
 
@@ -582,7 +588,9 @@ COPY --from=builder /app/target/release/rust_template /usr/local/bin/rust_templa
 ENTRYPOINT ["/usr/local/bin/rust_template"]
 ```
 
-Distroless is preferred for production because it contains no shell or package manager, reducing the attack surface. Use Debian slim if you need to debug inside the container or require additional runtime dependencies.
+Use Debian slim if you need to debug inside the container or require additional runtime dependencies.
+
+> **Why distroless by default?** It contains no shell or package manager, which reduces the runtime attack surface. Switch to Debian slim only when you need to debug inside the container or link additional runtime libraries.
 
 ### Adding runtime dependencies
 

--- a/docs/template/GETTING-STARTED.md
+++ b/docs/template/GETTING-STARTED.md
@@ -1,3 +1,7 @@
+---
+diataxis_type: how-to
+---
+
 # Getting Started
 
 > You just created a repository from **zircote/rust-template**. This guide walks you through every step from creation to your first green CI run.

--- a/docs/template/GITHUB-TEMPLATE-FEATURES.md
+++ b/docs/template/GITHUB-TEMPLATE-FEATURES.md
@@ -1,3 +1,7 @@
+---
+diataxis_type: reference
+---
+
 # GitHub Template Repository Features
 
 > What copies when someone clicks **"Use this template"** — and what doesn't.

--- a/docs/testing/PROPERTY-BASED-TESTING.md
+++ b/docs/testing/PROPERTY-BASED-TESTING.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: tutorial
+---
 # Property-Based Testing Guide
 
 ## Overview

--- a/docs/tutorials/first-project.md
+++ b/docs/tutorials/first-project.md
@@ -1,0 +1,511 @@
+---
+diataxis_type: tutorial
+---
+
+# Your First Project with rust-template
+
+Welcome! By the end of this tutorial you will have created your own repository
+from **zircote/rust-template**, built it, run its test suite, added your very
+first function, and watched GitHub's CI turn green. No prior experience with
+this template is required — just follow each step in order and you will end up
+with a working, fully-tested Rust crate.
+
+This is a **learning walkthrough**: every step is designed to succeed, and we
+explain the *why* as we go. When you finish you will understand how the template
+is laid out, why its source lives in `crates/` instead of `src/`, and how its
+quality gates protect your code. For task-focused recipes and lookup tables,
+each section links you to the matching how-to and reference docs at the end.
+
+> **Time:** about 20 minutes. **You will need:** a GitHub account and a
+> terminal. We install the Rust toolchain together in Step 2.
+
+---
+
+## What we will build
+
+You will turn the template's example crate into *your* crate and teach it one
+new trick: a `multiply` function that sits right next to the template's existing
+`add` function. Small on purpose — the point is to learn the full loop (edit →
+test → commit → CI) on a change that is guaranteed to work.
+
+Here is the whole journey:
+
+```text
+1. Use this template  ──>  your new GitHub repo
+2. Install Rust       ──>  rustc 1.92+
+3. Clone & build      ──>  first green test run locally
+4. Tour the layout    ──>  understand crates/, the example API
+5. Add multiply()     ──>  your first change, tested
+6. Commit & push      ──>  green CI on GitHub
+7. (Optional) /init   ──>  make it truly yours
+8. (Optional) release ──>  ship v0.1.0
+```
+
+Let's go.
+
+---
+
+## Step 1 — Create your repository from the template
+
+1. Open [zircote/rust-template](https://github.com/zircote/rust-template).
+2. Click the green **"Use this template"** button, then **"Create a new
+   repository"**.
+3. Choose an **owner** (your username or an organization).
+4. Give it a name. For this tutorial we will use `hello-rust` — pick anything
+   you like and substitute your name wherever you see `hello-rust` below.
+5. Pick **Public** or **Private**. Either works.
+6. Click **"Create repository"**.
+
+GitHub copies every file from the template into a brand-new repository that
+belongs to you. (It does *not* copy stars, issues, or commit history — a
+template gives you a clean starting point. The full breakdown of what copies
+lives in the [GitHub Template Features](../template/GITHUB-TEMPLATE-FEATURES.md)
+reference.)
+
+### What happens automatically
+
+The moment your repository exists, a workflow named **Template Init**
+(`template-init.yml`) runs once and rewrites the template's placeholder names to
+match your project:
+
+| Placeholder | Becomes |
+|---|---|
+| `zircote/rust-template` | `your-owner/hello-rust` |
+| `rust-template` | `hello-rust` (your repo name) |
+| `rust_template` | `hello_rust` (your crate name, underscored) |
+
+It takes about a minute and lands a commit titled
+`chore: initialize from rust-template ...`. After it runs, `Cargo.toml`,
+`README.md`, and the docs all point at your project.
+
+> **Good to know:** this automatic rename only *renames*. It keeps the
+> template's example code (the `add`, `divide`, and `Config` items you will meet
+> in Step 4) so you have something real to build on. Later, in Step 7, the
+> optional `/init-project` command strips that example code out when you are
+> ready to write your own.
+
+Give the workflow a minute to finish (you can watch it under the **Actions**
+tab), then continue.
+
+---
+
+## Step 2 — Install the Rust toolchain
+
+The template targets **Rust 1.92 or newer** (edition 2024). Install Rust with
+the official `rustup` installer, which manages your compiler and lets you switch
+versions later:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Follow the prompts, then reload your shell and verify:
+
+```bash
+source "$HOME/.cargo/env"
+rustup default stable
+rustc --version
+```
+
+You should see something like:
+
+```text
+rustc 1.92.0 (or newer)
+```
+
+> **Why rustup, not Homebrew?** `brew install rust` installs an unmanaged
+> toolchain that cannot switch versions, add cross-compilation targets, or run
+> the `rustup` commands this project uses. If you already installed Rust through
+> Homebrew, remove it first with
+> `brew uninstall rust rust-analyzer 2>/dev/null` and use rustup instead.
+
+That is everything you need to build and test. (A couple of optional convenience
+tools — `just` and `cargo-deny` — show up in Step 6; we will install them when
+we get there.)
+
+---
+
+## Step 3 — Clone and run your first build
+
+Clone the repository you created in Step 1 (replace the owner and name with
+yours):
+
+```bash
+git clone https://github.com/your-owner/hello-rust.git
+cd hello-rust
+```
+
+Now build and run the test suite — the most important habit in Rust:
+
+```bash
+cargo build
+cargo test
+```
+
+The first `cargo build` downloads dependencies and compiles the crate, so it
+takes a little longer than later runs. When `cargo test` finishes you will see
+output that looks like this (exact counts will vary):
+
+```text
+   Compiling hello_rust v0.1.0 (/path/to/hello-rust)
+    Finished test [unoptimized + debuginfo] target(s)
+     Running unittests crates/lib.rs
+
+running 9 tests
+test tests::test_add ... ok
+test tests::test_divide_success ... ok
+test tests::test_config_builder ... ok
+...
+test result: ok. 9 passed; 0 failed; 0 ignored
+
+   Doc-tests hello_rust
+test result: ok. 3 passed; 0 failed
+```
+
+🎉 **That is your first green run.** Everything compiled and every test passed.
+
+Notice the two kinds of tests that ran: the `running ... tests` block is the
+unit tests, and the `Doc-tests` block at the bottom ran the code examples
+embedded in the documentation comments. In this template, **your examples are
+tests** — if a `# Examples` block stops compiling, `cargo test` fails. That is a
+feature, and you will use it in Step 5.
+
+You can also run the example binary:
+
+```bash
+cargo run
+```
+
+```text
+2 + 3 = 5
+10 / 2 = 5
+```
+
+---
+
+## Step 4 — Tour the layout
+
+Before changing anything, let's understand what you are looking at. This is the
+knowledge that makes every later step obvious.
+
+```text
+hello-rust/
+├── crates/
+│   ├── lib.rs              # Library root — the public API lives here
+│   └── main.rs             # Binary entry point (uses the library)
+├── tests/
+│   └── integration_test.rs # Tests that use the crate as an outside user would
+├── Cargo.toml              # Package manifest (name, deps, lints, profiles)
+├── clippy.toml             # Linter thresholds
+├── rustfmt.toml            # Formatter rules
+├── deny.toml               # Supply-chain policy (licenses, banned crates)
+└── justfile                # Shortcuts for the CI commands
+```
+
+### Why `crates/`, not `src/`?
+
+Most Rust projects keep code in `src/`. This template deliberately uses
+`crates/` to signal that it is a template you are meant to reshape — and to make
+room for growing into a multi-crate workspace later. The paths are wired up in
+`Cargo.toml` under `[lib]` and `[[bin]]`, so the compiler always knows where to
+look. Everything else (`cargo build`, `cargo test`, `cargo run`) works exactly
+as normal.
+
+### Meet the example API
+
+Open `crates/lib.rs`. It is short and worth reading top to bottom. It
+demonstrates the patterns this template wants you to follow:
+
+```rust
+/// Error type for `hello_rust` operations.
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+
+    #[error("operation '{operation}' failed: {cause}")]
+    OperationFailed { operation: String, cause: String },
+}
+
+/// Result type alias for `hello_rust` operations.
+pub type Result<T> = std::result::Result<T, Error>;
+```
+
+A few concepts to take away:
+
+- **`Error` is one enum derived with `thiserror`.** The `#[error("...")]`
+  attribute generates the human-readable message for each variant, so you never
+  hand-write a `Display` implementation. `#[non_exhaustive]` lets you add new
+  variants later without breaking callers.
+- **`Result<T>` is a crate-wide alias** for `std::result::Result<T, Error>`. It
+  means functions can return `Result<i64>` instead of repeating the full type
+  everywhere — and the `?` operator just works.
+
+Below that are the example functions:
+
+| Item | What it shows |
+|---|---|
+| `add(a, b)` | A pure `const fn`, marked `#[must_use]`, with a doctest |
+| `divide(dividend, divisor)` | A fallible function returning `Result<i64>` |
+| `process(input)` | Parsing input and returning typed errors |
+| `Config` | A consuming-self builder (`Config::new().with_verbose(true)`) |
+
+These exist purely to teach the patterns. In Step 5 you will add a function in
+the same style as `add` — copying a known-good shape is the safest way to make a
+change that passes every gate on the first try.
+
+> Want the full design rationale (why `thiserror`, why consuming builders, why
+> the strict lints)? It lives in the project's `CLAUDE.md` under
+> **Explanation**. For now, you know enough to make your first change.
+
+---
+
+## Step 5 — Make your first change: add `multiply`
+
+You will add a `multiply` function right next to `add`. We model it on `add`
+because `add` already passes every check — so by mirroring its shape (a pure
+`const fn`, `#[must_use]`, a full doc comment with a runnable example), your new
+function is correct by construction.
+
+### 5a. Add the function to `crates/lib.rs`
+
+Open `crates/lib.rs` and add this function just below the existing `add`
+function (before `divide` is a fine spot):
+
+```rust
+/// Multiplies two numbers together.
+///
+/// # Arguments
+///
+/// * `a` - The first factor.
+/// * `b` - The second factor.
+///
+/// # Returns
+///
+/// The product of `a` and `b`.
+///
+/// # Examples
+///
+/// ```rust
+/// use hello_rust::multiply;
+///
+/// assert_eq!(multiply(2, 3), 6);
+/// assert_eq!(multiply(-4, 5), -20);
+/// ```
+#[must_use]
+pub const fn multiply(a: i64, b: i64) -> i64 {
+    a * b
+}
+```
+
+Use your own crate name in the `use` line — if you named your repo `hello-rust`,
+the crate is `hello_rust` (hyphens become underscores).
+
+Two things this small function teaches:
+
+- **`#[must_use]`** tells the compiler to warn if a caller ignores the return
+  value. The template's pedantic lints expect it on pure functions like this.
+- **The `# Examples` block is a real test.** `cargo test` compiles and runs it.
+  If you typo the assertion, the build fails — your documentation can never drift
+  out of sync with your code.
+
+### 5b. Add a unit test
+
+Scroll to the `#[cfg(test)] mod tests` block near the bottom of the same file
+and add a test alongside `test_add`:
+
+```rust
+    #[test]
+    fn test_multiply() {
+        assert_eq!(multiply(2, 3), 6);
+        assert_eq!(multiply(-4, 5), -20);
+        assert_eq!(multiply(0, 100), 0);
+    }
+```
+
+### 5c. Add an integration test
+
+Unit tests live *inside* the library. Integration tests live in `tests/` and
+exercise your crate the way an outside user would — through its public API only.
+Open `tests/integration_test.rs` and add:
+
+```rust
+#[test]
+fn multiply_works_from_outside() {
+    assert_eq!(hello_rust::multiply(6, 7), 42);
+}
+```
+
+Again, swap `hello_rust` for your crate name.
+
+### 5d. Run the tests
+
+```bash
+cargo test
+```
+
+You should now see your new tests among the output, all passing (cargo prints a
+separate `test result:` line for each group — unit tests, integration tests, and
+doctests):
+
+```text
+test tests::test_multiply ... ok
+...
+test multiply_works_from_outside ... ok
+...
+test result: ok. 0 failed
+```
+
+If something failed, read the message — Rust's compiler errors are famously
+helpful. The usual culprits are a wrong crate name in the `use` line or a
+mismatched bracket. Fix it and re-run; this loop (`edit → cargo test`) is the
+heartbeat of Rust development.
+
+You just added a function, documented it, and proved it works three different
+ways. Nice.
+
+---
+
+## Step 6 — Run the full checks, then commit
+
+`cargo test` is the fast inner loop. Before pushing, run the same gates CI will
+run so there are no surprises. The template bundles them behind a single command
+using [`just`](https://github.com/casey/just), a small task runner. Install
+`just` and `cargo-deny` (used by one of the checks):
+
+```bash
+cargo install just cargo-deny
+```
+
+> **Shortcut:** if you opened this repo in a GitHub Codespace or the provided
+> dev container, `just` and `cargo-deny` are already installed — skip the
+> install command.
+
+Now run the full check suite:
+
+```bash
+just check
+```
+
+This runs formatting, the Clippy linter, the tests, a documentation build, and
+the supply-chain audit — exactly what GitHub runs on every push. If you prefer
+the raw commands (no `just` needed), they are:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+cargo doc --no-deps --all-features
+cargo deny check
+```
+
+When everything is green, commit and push:
+
+```bash
+git add -A
+git commit -m "feat: add multiply function"
+git push
+```
+
+### Watch CI go green
+
+Open your repository on GitHub and click the **Actions** tab. Your push kicked
+off the pipeline. After a few minutes you will see a green check mark next to
+your commit — the same checks you just ran locally, now confirmed on Linux,
+macOS, and Windows.
+
+✅ **You shipped a tested change and CI is green.** That is the complete
+professional loop, start to finish.
+
+If a check ever fails on GitHub but passed locally (or vice versa), the
+[CI Troubleshooting](../runbooks/CI-TROUBLESHOOTING.md) runbook maps each
+failure to its fix.
+
+---
+
+## Step 7 — (Optional) Make it truly yours with `/init-project`
+
+So far you have been building on the template's example code. When you are ready
+to start your *real* project, you have two ways to clear the examples out:
+
+- **By hand:** the [Customization](../template/CUSTOMIZATION.md) guide walks
+  through removing the example functions and replacing the README.
+- **Automated:** if you use Claude Code, run the **`/init-project`** command. It
+  interviews you (crate name, description, author, library-only vs.
+  library+binary, distribution channels), then renames everything, strips the
+  example `add`/`divide`/`Config` code down to a clean stub, configures your
+  distribution channels, and verifies the result builds clean.
+
+> **Heads up — this is destructive.** `/init-project` *removes* the example API
+> you used in Steps 4 and 5. That is the point: it hands you an empty, correctly
+> wired crate to fill with your own code. Run it only once you no longer need the
+> examples. After it finishes, your "first change" becomes adding a brand-new
+> function to the stub (the same pattern you practiced with `multiply`).
+
+This step is genuinely optional. Many people keep building on the example code
+for a while first. Do it whenever it feels right.
+
+---
+
+## Step 8 — (Optional) Cut your first release
+
+When you have something worth sharing, the template can build signed,
+attested release binaries for five platforms, generate a software bill of
+materials, and (in a real project) publish to crates.io and Homebrew.
+
+In the **template** itself, publication is intentionally switched off
+(`publish = false` in `Cargo.toml`), so a release runs the full build-and-verify
+chain as a dry run without pushing anything outward. Deleting that one line — or
+letting `/init-project` remove it for you — arms the real publishing channels.
+
+The short version of cutting a release:
+
+```bash
+# Bump the version in Cargo.toml, commit it, then:
+git tag -a v0.1.0 -m "Release v0.1.0"
+git push origin v0.1.0
+```
+
+Pushing a `v*.*.*` tag triggers the release automation. The full, careful
+procedure — pre-release checklist, monitoring each workflow, and rollback — is
+in the [Releasing](../runbooks/RELEASING.md) runbook. Read it before your first
+real release.
+
+---
+
+## What you learned
+
+In one sitting you:
+
+- **Created a repository from a template** and saw the automatic rename wire up
+  your project name everywhere.
+- **Installed a rustup-managed toolchain** the way the project expects.
+- **Built and tested** a Rust crate, and learned that *doctests are real tests*.
+- **Understood the layout** — why source lives in `crates/`, and how `Error`,
+  the `Result<T>` alias, the example functions, and the `Config` builder
+  demonstrate the template's patterns.
+- **Added a function the safe way** — mirroring a known-good shape — with a doc
+  example, a unit test, and an integration test.
+- **Ran the full quality gate** locally and **watched the same checks pass in
+  CI** across three operating systems.
+- **Learned the two optional next moves:** stripping the examples with
+  `/init-project`, and cutting an attested release.
+
+You now have everything you need to build something real.
+
+## Where to go next
+
+| If you want to… | Read |
+|---|---|
+| Follow a task-focused setup checklist (secrets, signing, options) | [Getting Started](../template/GETTING-STARTED.md) (how-to) |
+| Configure `Cargo.toml`, features, profiles, and lints | [Configuration](../template/CONFIGURATION.md) (how-to) |
+| Add modules, go library-only, adjust lints, customize Docker | [Customization](../template/CUSTOMIZATION.md) (how-to) |
+| Have AI scaffold a whole project for you | [Copilot Jumpstart](../template/COPILOT-JUMPSTART.md) (how-to) |
+| Look up exactly what every CI workflow does | [CI Workflows](../template/CI-WORKFLOWS.md) (reference) |
+| See what copies when you "Use this template" | [GitHub Template Features](../template/GITHUB-TEMPLATE-FEATURES.md) (reference) |
+| Fix a failing CI check | [CI Troubleshooting](../runbooks/CI-TROUBLESHOOTING.md) (how-to) |
+| Cut and verify a release | [Releasing](../runbooks/RELEASING.md) (how-to) |
+| Understand the design rationale (why `thiserror`, `crates/`, strict lints) | `CLAUDE.md` → Explanation |
+
+Happy building. 🦀

--- a/docs/ux/MAN-PAGES.md
+++ b/docs/ux/MAN-PAGES.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # Man Pages Generation
 
 ## Overview

--- a/docs/ux/SHELL-COMPLETIONS.md
+++ b/docs/ux/SHELL-COMPLETIONS.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # Shell Completions
 
 ## Overview

--- a/docs/workflows/BENCHMARK-REGRESSION.md
+++ b/docs/workflows/BENCHMARK-REGRESSION.md
@@ -11,18 +11,17 @@ Automated performance benchmarking with regression detection using [Criterion.rs
 |---|---|
 | Workflow | `.github/workflows/benchmark-regression.yml` |
 | Tool | Criterion.rs |
-| Triggers | PR, push to main, manual dispatch |
+| Triggers | Pull requests + manual (`workflow_dispatch`) |
 | Goal | Prevent performance regressions |
 
 ### CI pipeline stages
 
 The workflow runs these stages automatically:
 
-1. **Baseline** — store performance metrics from the main branch.
-2. **Current** — run benchmarks on the PR/current branch.
-3. **Compare** — calculate the performance change vs. baseline.
-4. **Report** — comment on the PR with results.
-5. **Update** — save the new baseline when merging to main.
+1. **Restore** — restore a cached baseline (`target/criterion`) from a prior run, if one exists.
+2. **Run** — run the benchmarks under `benches/` (if present) on the PR branch.
+3. **Report** — generate `benchmark-report.md` from the run output.
+4. **Upload** — upload the `benchmark-results` artifact (report, `target/criterion/`, raw output; 90-day retention).
 
 ### Benchmark output
 
@@ -63,13 +62,15 @@ Significant — real performance degradation detected.
 
 ### Regression detection criteria
 
-The workflow flags a regression when all of the following hold:
+> **Not automated.** The workflow runs the benchmarks and uploads the results, but it does **not** gate the PR on a regression — its compare step always reports no regression. Use these criteria when reviewing the uploaded artifact (or comparing locally with `cargo bench -- --baseline …`) to decide whether a change is a real regression:
 
 1. **Statistical significance** (`p < 0.05`).
 2. **Magnitude** (`> 5%` slower).
 3. **Consistency** (median in the regression range).
 
-### PR comment example
+### Benchmark report artifact
+
+The workflow writes a `benchmark-report.md` into the `benchmark-results` artifact (it does **not** post a PR comment). The report wraps the tail of the raw `cargo bench` output; for example:
 
 ```markdown
 # Benchmark Results
@@ -352,7 +353,7 @@ cargo bench -- --measurement-time 1
 
 ## Why this matters
 
-Performance is a property that erodes silently: a single PR rarely makes the code dramatically slower, but a year of unmeasured changes can. Storing a baseline from main and comparing every PR against it turns that slow drift into an explicit, reviewable signal. The statistical significance test (`p < 0.05`) and the noise threshold exist because microbenchmarks are jittery — without them, every run would look like a regression and the signal would be ignored. Pairing the threshold with profiling (flamegraph/perf) means a flagged regression leads to a root cause, not just a red mark.
+Performance is a property that erodes silently: a single PR rarely makes the code dramatically slower, but a year of unmeasured changes can. Running benchmarks on every PR and uploading the results turns that slow drift into a reviewable signal you can inspect per change. The statistical significance test (`p < 0.05`) and the noise threshold exist because microbenchmarks are jittery — without them, every run would look like a regression and the signal would be ignored. Pairing the threshold with profiling (flamegraph/perf) means a flagged regression leads to a root cause, not just a red mark. The template does not yet gate merges on a regression automatically; comparison against a baseline is done by reviewing the artifact or running `cargo bench -- --baseline …` locally.
 
 ## Links
 

--- a/docs/workflows/BENCHMARK-REGRESSION.md
+++ b/docs/workflows/BENCHMARK-REGRESSION.md
@@ -1,97 +1,30 @@
+---
+diataxis_type: how-to
+---
 # Benchmark Regression Detection
 
-## Overview
+Automated performance benchmarking with regression detection using [Criterion.rs](https://github.com/bheisler/criterion.rs), so performance regressions are caught before they merge.
 
-Automated performance benchmarking with regression detection using [Criterion.rs](https://github.com/bheisler/criterion.rs).
+## Reference
 
-**Workflow:** `.github/workflows/benchmark-regression.yml`
-**Tool:** Criterion.rs
-**Triggers:** PR, Push to main, Manual dispatch
-**Goal:** Prevent performance regressions
+| Field | Value |
+|---|---|
+| Workflow | `.github/workflows/benchmark-regression.yml` |
+| Tool | Criterion.rs |
+| Triggers | PR, push to main, manual dispatch |
+| Goal | Prevent performance regressions |
 
-## How It Works
+### CI pipeline stages
 
-1. **Baseline**: Store performance metrics from main branch
-2. **Current**: Run benchmarks on PR/current branch
-3. **Compare**: Calculate performance change vs baseline
-4. **Report**: Comment on PR with results
-5. **Update**: Save new baseline when merging to main
+The workflow runs these stages automatically:
 
-## Setup Benchmarks
+1. **Baseline** — store performance metrics from the main branch.
+2. **Current** — run benchmarks on the PR/current branch.
+3. **Compare** — calculate the performance change vs. baseline.
+4. **Report** — comment on the PR with results.
+5. **Update** — save the new baseline when merging to main.
 
-### Directory Structure
-
-```text
-benches/
-├── my_benchmark.rs
-└── another_benchmark.rs
-```
-
-### Example Benchmark
-
-**`benches/performance.rs`:**
-
-```rust
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use rust_template::expensive_function;
-
-fn benchmark_expensive_function(c: &mut Criterion) {
-    c.bench_function("expensive_function", |b| {
-        b.iter(|| expensive_function(black_box(100)))
-    });
-}
-
-fn benchmark_with_setup(c: &mut Criterion) {
-    c.bench_function("with_setup", |b| {
-        let data = vec![1, 2, 3, 4, 5];
-        b.iter(|| {
-            process(black_box(&data))
-        })
-    });
-}
-
-criterion_group!(benches, benchmark_expensive_function, benchmark_with_setup);
-criterion_main!(benches);
-```
-
-**Add to `Cargo.toml`:**
-
-```toml
-[[bench]]
-name = "performance"
-harness = false
-```
-
-## Running Benchmarks
-
-### Locally
-
-```bash
-# Run all benchmarks
-cargo bench
-
-# Run specific benchmark
-cargo bench --bench performance
-
-# Save baseline
-cargo bench -- --save-baseline main
-
-# Compare against baseline
-cargo bench -- --baseline main
-```
-
-### CI Integration
-
-The workflow automatically:
-- Downloads baseline from main branch
-- Runs current benchmarks
-- Compares performance
-- Posts results to PR
-- Updates baseline on merge to main
-
-## Understanding Results
-
-### Benchmark Output
+### Benchmark output
 
 ```text
 expensive_function      time:   [48.123 µs 48.567 µs 49.012 µs]
@@ -99,103 +32,148 @@ expensive_function      time:   [48.123 µs 48.567 µs 49.012 µs]
                         Performance has improved.
 ```
 
-**Interpretation:**
-- **time**: Current execution time (min, median, max)
-- **change**: % change from baseline
-- **p-value**: Statistical significance (< 0.05 = significant)
+- **time**: current execution time (min, median, max).
+- **change**: percent change from baseline.
+- **p-value**: statistical significance (`< 0.05` = significant).
 
-### Performance Change
+### Performance change thresholds
 
 | Change | Interpretation | Action |
 |--------|---------------|--------|
-| < -5% | **Improvement** ✅ | Great! Document what improved |
-| -5% to +5% | **No change** ⚪ | Within noise threshold |
-| +5% to +20% | **Minor regression** ⚠️ | Investigate if acceptable |
-| > +20% | **Major regression** ❌ | Must fix before merge |
+| `< -5%` | **Improvement** ✅ | Great — document what improved |
+| `-5%` to `+5%` | **No change** ⚪ | Within noise threshold |
+| `+5%` to `+20%` | **Minor regression** ⚠️ | Investigate if acceptable |
+| `> +20%` | **Major regression** ❌ | Must fix before merge |
 
-### Statistical Significance
+### Statistical significance
 
 ```text
 change: [+2.5% +5.2% +7.8%] (p = 0.45 > 0.05)
 Change within noise threshold.
 ```
 
-**Not significant** - variation likely due to noise, not real change.
+Not significant — variation likely due to noise, not a real change.
 
 ```text
 change: [+15.2% +18.5% +21.3%] (p = 0.001 < 0.05)
 Performance has regressed.
 ```
 
-**Significant** - real performance degradation detected.
+Significant — real performance degradation detected.
 
-## Benchmark Best Practices
+### Regression detection criteria
 
-### Use `black_box`
+The workflow flags a regression when all of the following hold:
 
-```rust
-// ❌ Bad - Compiler optimizes away
-b.iter(|| expensive_function(100));
+1. **Statistical significance** (`p < 0.05`).
+2. **Magnitude** (`> 5%` slower).
+3. **Consistency** (median in the regression range).
 
-// ✅ Good - Prevents optimization
-b.iter(|| expensive_function(black_box(100)));
+### PR comment example
+
+```markdown
+# Benchmark Results
+
+## Performance Summary
+
+| Benchmark | Baseline | Current | Change |
+|-----------|----------|---------|--------|
+| parse_small | 1.23 µs | 1.20 µs | -2.4% ✅ |
+| parse_large | 45.6 µs | 52.3 µs | +14.7% ⚠️ |
+| compute | 234 ns | 236 ns | +0.9% ⚪ |
+
+## Regressions Detected ⚠️
+
+**parse_large**: 14.7% slower (p < 0.01)
+- Review recent changes to parsing logic
+- Consider optimization or accept tradeoff
 ```
 
-### Avoid Setup in Measurement
+### Criterion HTML reports
 
-```rust
-// ❌ Bad - Includes allocation in measurement
-b.iter(|| {
-    let data = vec![1, 2, 3];  // Measured
-    process(&data)
-});
+Criterion generates HTML reports under `target/criterion/`:
 
-// ✅ Good - Setup outside measurement
-let data = vec![1, 2, 3];
-b.iter(|| process(black_box(&data)));
+```text
+target/criterion/
+├── expensive_function/
+│   ├── report/
+│   │   ├── index.html
+│   │   └── violin.svg
+│   └── base/
+└── report/
+    └── index.html
 ```
 
-### Benchmark Representative Sizes
+Open `target/criterion/report/index.html` to view them.
 
-```rust
-c.bench_function("small input", |b| {
-    b.iter(|| parse(black_box("short")))
-});
+## How-to
 
-c.bench_function("large input", |b| {
-    let large = "x".repeat(10_000);
-    b.iter(|| parse(black_box(&large)))
-});
+### Set up benchmarks
+
+1. Create a `benches/` directory at the crate root:
+
+   ```text
+   benches/
+   ├── my_benchmark.rs
+   └── another_benchmark.rs
+   ```
+
+2. Write a benchmark file, `benches/performance.rs`:
+
+   ```rust
+   use criterion::{black_box, criterion_group, criterion_main, Criterion};
+   use rust_template::expensive_function;
+
+   fn benchmark_expensive_function(c: &mut Criterion) {
+       c.bench_function("expensive_function", |b| {
+           b.iter(|| expensive_function(black_box(100)))
+       });
+   }
+
+   fn benchmark_with_setup(c: &mut Criterion) {
+       c.bench_function("with_setup", |b| {
+           let data = vec![1, 2, 3, 4, 5];
+           b.iter(|| {
+               process(black_box(&data))
+           })
+       });
+   }
+
+   criterion_group!(benches, benchmark_expensive_function, benchmark_with_setup);
+   criterion_main!(benches);
+   ```
+
+3. Register the bench target in `Cargo.toml`:
+
+   ```toml
+   [[bench]]
+   name = "performance"
+   harness = false
+   ```
+
+4. Verify: `cargo bench --bench performance`.
+
+### Run benchmarks locally
+
+```bash
+# Run all benchmarks
+cargo bench
+
+# Run a specific benchmark
+cargo bench --bench performance
+
+# Save a baseline
+cargo bench -- --save-baseline main
+
+# Compare against a baseline
+cargo bench -- --baseline main
 ```
 
-### Parameterized Benchmarks
+Verify: confirm the run prints `time:` and `change:` lines.
 
-```rust
-use criterion::{BenchmarkId, Criterion};
+### Configure Criterion
 
-fn bench_sizes(c: &mut Criterion) {
-    let mut group = c.benchmark_group("parse_sizes");
-
-    for size in [10, 100, 1000, 10000] {
-        group.bench_with_input(
-            BenchmarkId::from_parameter(size),
-            &size,
-            |b, &size| {
-                let input = "x".repeat(size);
-                b.iter(|| parse(black_box(&input)))
-            }
-        );
-    }
-
-    group.finish();
-}
-```
-
-## Configuration
-
-### Criterion Settings
-
-**`benches/benchmark.rs`:**
+Tune sampling in `benches/benchmark.rs`:
 
 ```rust
 use criterion::{Criterion, SamplingMode};
@@ -216,9 +194,7 @@ criterion_group! {
 }
 ```
 
-### Workflow Settings
-
-**Adjust duration:**
+Adjust the CI run duration in the workflow:
 
 ```yaml
 # .github/workflows/benchmark-regression.yml
@@ -227,109 +203,53 @@ inputs:
     default: '300'  # 5 minutes
 ```
 
-## Regression Detection
+Verify: `cargo bench` and check the warm-up/measurement times in the output.
 
-### Threshold Configuration
+### Investigate a regression
 
-The workflow detects regressions using:
+1. Profile to find the hot path:
 
-1. **Statistical significance** (p < 0.05)
-2. **Magnitude** (> 5% slower)
-3. **Consistency** (median in regression range)
+   ```bash
+   cargo install flamegraph
+   cargo flamegraph --bench performance
+   ```
 
-### Manual Threshold
+   ```bash
+   perf record --call-graph dwarf cargo bench
+   perf report
+   ```
+
+2. Choose an outcome:
+   - **Fix** — optimize the code.
+   - **Accept** — document the tradeoff (e.g., correctness over speed).
+   - **Defer** — open an issue for future optimization.
+
+3. Document an accepted tradeoff in the source:
+
+   ```rust
+   // Intentional tradeoff: Added validation reduces performance by ~10%
+   // See issue #123 for optimization ideas
+   fn parse(input: &str) -> Result<Output> {
+       validate(input)?;  // New validation (slower but correct)
+       // ...
+   }
+   ```
+
+Verify: re-run `cargo bench -- --baseline main` and confirm the change is acknowledged or resolved.
+
+### Run advanced benchmarks
 
 ```bash
-# Fail if > 10% slower
+# Compare multiple baselines
+cargo bench -- --save-baseline main
+cargo bench -- --save-baseline before-refactor
+cargo bench -- --baseline before-refactor
+
+# Manual significance level
 cargo bench -- --baseline main --significance-level 0.05
 ```
 
-## Interpreting CI Reports
-
-### PR Comment Example
-
-```markdown
-# Benchmark Results
-
-## Performance Summary
-
-| Benchmark | Baseline | Current | Change |
-|-----------|----------|---------|--------|
-| parse_small | 1.23 µs | 1.20 µs | -2.4% ✅ |
-| parse_large | 45.6 µs | 52.3 µs | +14.7% ⚠️ |
-| compute | 234 ns | 236 ns | +0.9% ⚪ |
-
-## Regressions Detected ⚠️
-
-**parse_large**: 14.7% slower (p < 0.01)
-- Review recent changes to parsing logic
-- Consider optimization or accept tradeoff
-```
-
-**Action:** Investigate `parse_large` regression.
-
-## Handling Regressions
-
-### Investigate
-
-```bash
-# Profile with cargo-flamegraph
-cargo install flamegraph
-cargo flamegraph --bench performance
-
-# Check with perf
-perf record --call-graph dwarf cargo bench
-perf report
-```
-
-### Options
-
-1. **Fix** - Optimize the code
-2. **Accept** - Document tradeoff (e.g., correctness > speed)
-3. **Defer** - Create issue for future optimization
-
-### Document Acceptance
-
-```rust
-// Intentional tradeoff: Added validation reduces performance by ~10%
-// See issue #123 for optimization ideas
-fn parse(input: &str) -> Result<Output> {
-    validate(input)?;  // New validation (slower but correct)
-    // ...
-}
-```
-
-## Advanced Features
-
-### Compare Multiple Baselines
-
-```bash
-# Save different baselines
-cargo bench -- --save-baseline main
-cargo bench -- --save-baseline before-refactor
-
-# Compare
-cargo bench -- --baseline before-refactor
-```
-
-### Custom Plots
-
-Criterion generates HTML reports:
-
-```text
-target/criterion/
-├── expensive_function/
-│   ├── report/
-│   │   ├── index.html
-│   │   └── violin.svg
-│   └── base/
-└── report/
-    └── index.html
-```
-
-**View:** Open `target/criterion/report/index.html`
-
-### Throughput Measurement
+Measure throughput instead of time/iteration:
 
 ```rust
 c.bench_function("process_bytes", |b| {
@@ -339,23 +259,12 @@ c.bench_function("process_bytes", |b| {
 });
 ```
 
-**Output:** MB/s instead of time/iteration.
+Verify: throughput output reports MB/s.
 
-## Troubleshooting
+### Troubleshooting
 
-### Noisy Results
+**Noisy results** (`change: [-15% +2% +18%] (p = 0.52)`) — caused by CPU frequency scaling, background processes, or thermal throttling:
 
-```text
-change: [-15% +2% +18%] (p = 0.52)
-Change within noise threshold.
-```
-
-**Causes:**
-- CPU frequency scaling
-- Background processes
-- Thermal throttling
-
-**Solutions:**
 ```bash
 # Increase sample size
 cargo bench -- --sample-size 1000
@@ -364,29 +273,86 @@ cargo bench -- --sample-size 1000
 sudo cpupower frequency-set --governor performance
 ```
 
-### Missing Baseline
+**Missing baseline** (`Warning: No baseline found for benchmark`) — run once on the main branch to establish a baseline.
 
-```text
-Warning: No baseline found for benchmark
-```
-
-**Fix:** Run once on main branch to establish baseline.
-
-### Slow Benchmarks
+**Slow benchmarks**:
 
 ```bash
-# Reduce measurement time
 cargo bench -- --measurement-time 1
 ```
 
-## Best Practices
+### Benchmark best practices
 
-1. **Benchmark hot paths** - Focus on critical performance code
-2. **Use realistic inputs** - Benchmark with production-like data
-3. **Isolate variables** - One change at a time
-4. **Accept some variation** - ±5% is often noise
-5. **Profile before optimizing** - Use flamegraph/perf
-6. **Document tradeoffs** - Sometimes slower is better (safety, correctness)
+1. **Use `black_box`** to stop the compiler optimizing the work away:
+
+   ```rust
+   // ❌ Bad - Compiler optimizes away
+   b.iter(|| expensive_function(100));
+
+   // ✅ Good - Prevents optimization
+   b.iter(|| expensive_function(black_box(100)));
+   ```
+
+2. **Keep setup out of measurement**:
+
+   ```rust
+   // ❌ Bad - Includes allocation in measurement
+   b.iter(|| {
+       let data = vec![1, 2, 3];  // Measured
+       process(&data)
+   });
+
+   // ✅ Good - Setup outside measurement
+   let data = vec![1, 2, 3];
+   b.iter(|| process(black_box(&data)));
+   ```
+
+3. **Benchmark representative sizes**:
+
+   ```rust
+   c.bench_function("small input", |b| {
+       b.iter(|| parse(black_box("short")))
+   });
+
+   c.bench_function("large input", |b| {
+       let large = "x".repeat(10_000);
+       b.iter(|| parse(black_box(&large)))
+   });
+   ```
+
+4. **Parameterize over inputs**:
+
+   ```rust
+   use criterion::{BenchmarkId, Criterion};
+
+   fn bench_sizes(c: &mut Criterion) {
+       let mut group = c.benchmark_group("parse_sizes");
+
+       for size in [10, 100, 1000, 10000] {
+           group.bench_with_input(
+               BenchmarkId::from_parameter(size),
+               &size,
+               |b, &size| {
+                   let input = "x".repeat(size);
+                   b.iter(|| parse(black_box(&input)))
+               }
+           );
+       }
+
+       group.finish();
+   }
+   ```
+
+5. **Benchmark hot paths** — focus on critical performance code.
+6. **Use realistic inputs** — production-like data.
+7. **Isolate variables** — one change at a time.
+8. **Accept some variation** — ±5% is often noise.
+9. **Profile before optimizing** — use flamegraph/perf.
+10. **Document tradeoffs** — sometimes slower is better (safety, correctness).
+
+## Why this matters
+
+Performance is a property that erodes silently: a single PR rarely makes the code dramatically slower, but a year of unmeasured changes can. Storing a baseline from main and comparing every PR against it turns that slow drift into an explicit, reviewable signal. The statistical significance test (`p < 0.05`) and the noise threshold exist because microbenchmarks are jittery — without them, every run would look like a regression and the signal would be ignored. Pairing the threshold with profiling (flamegraph/perf) means a flagged regression leads to a root cause, not just a red mark.
 
 ## Links
 
@@ -394,3 +360,4 @@ cargo bench -- --measurement-time 1
 - [Benchmark Analysis](https://bheisler.github.io/criterion.rs/book/analysis.html)
 - [cargo-flamegraph](https://github.com/flamegraph-rs/flamegraph)
 - [Rust Performance Book](https://nnethercote.github.io/perf-book/)
+- [CI Workflows reference](../template/CI-WORKFLOWS.md)

--- a/docs/workflows/CODE-QUALITY.md
+++ b/docs/workflows/CODE-QUALITY.md
@@ -1,46 +1,81 @@
+---
+diataxis_type: how-to
+---
 # Code Quality Metrics
 
-## Overview
+Automated collection of code quality metrics — unsafe code detection, binary size analysis, and documentation coverage — emitted as a single report artifact.
 
-Automated collection of code quality metrics including unsafe code detection, binary size analysis, and documentation coverage.
+## Reference
 
-**Workflow:** `.github/workflows/code-quality.yml`  
-**Tools:** `cargo-geiger`, `cargo-bloat`, `rustdoc`  
-**Output:** Markdown report artifact
+| Field | Value |
+|---|---|
+| Workflow | `.github/workflows/code-quality.yml` |
+| Tools | `cargo-geiger`, `cargo-bloat`, `rustdoc` |
+| Output | Markdown report artifact |
 
-## Metrics Collected
+### Metrics collected
 
-### 1. Unsafe Code Analysis (cargo-geiger)
+| Metric | Tool | What it detects |
+|---|---|---|
+| Unsafe code analysis | `cargo-geiger` | Unsafe function calls, blocks, trait impls, and unsafe in dependencies |
+| Binary size analysis | `cargo-bloat` | Size by crate and by function; bloat sources |
+| Documentation coverage | `rustdoc` | Missing doc comments, broken doc links, doc test failures |
 
-Detects unsafe code usage:
-- Unsafe function calls
-- Unsafe blocks
-- Unsafe trait implementations
-- Dependencies with unsafe code
+### Report access
 
-**Why it matters:** Unsafe code bypasses Rust's safety guarantees.
+The workflow generates a combined report. Access it via **Actions → Code Quality Metrics → Artifacts → code-quality-metrics**.
 
-### 2. Binary Size Analysis (cargo-bloat)
+Example report:
 
-Analyzes what contributes to binary size:
-- Size by crate
-- Size by function
-- Identifies bloat
+```markdown
+## Unsafe Code Analysis
+Functions  Expressions  Impls  Traits  Methods  Dependency
+0/10       0/100        0/5    0/2     0/20     rust_template
 
-**Why it matters:** Smaller binaries = faster downloads, less memory.
+## Binary Size Analysis
+File   .text   Size    Crate
+ 71.0%  59.0%   1.2MiB  std
+  8.5%   7.1%   147KiB  rust_template
 
-### 3. Documentation Coverage
+## Documentation Coverage
+Documenting rust_template v0.1.0
+warning: missing documentation for public function
+```
 
-Checks documentation completeness:
-- Missing doc comments
-- Broken doc links
-- Doc test failures
+### Interpreting the unsafe code report
 
-**Why it matters:** Well-documented APIs are easier to use.
+```text
+Functions  Expressions  Impls  Traits  Methods  Dependency
+2/10       5/100        0/5    0/2     0/20     ✓ rust_template
+```
 
-## Usage
+- **Functions**: 2 functions contain unsafe code.
+- **Expressions**: 5 unsafe expressions total.
+- **✓** = no unsafe in this crate's API.
 
-### Local Analysis
+### Interpreting the binary size report
+
+```text
+File   .text   Size    Crate
+71.0%  59.0%   1.2MiB  std        ← Standard library
+ 8.5%   7.1%   147KiB  rust_template
+ 5.2%   4.3%   89KiB   serde
+```
+
+A large dependency contribution (e.g. `serde`) is a candidate for feature-flag trimming.
+
+### Interpreting documentation coverage
+
+```text
+warning: missing documentation for public function `add`
+  --> crates/lib.rs:10
+```
+
+Each warning names the public item that needs a doc comment.
+
+## How-to
+
+### Run the analysis locally
 
 ```bash
 # Install tools
@@ -57,33 +92,11 @@ cargo bloat --release --crates
 cargo doc --no-deps --all-features
 ```
 
-### CI Reports
+Verify: each command prints a report section matching the formats above.
 
-The workflow generates a combined report:
+### Configure unsafe code policy
 
-**Access:** Actions → Code Quality Metrics → Artifacts → code-quality-metrics
-
-**Example Report:**
-```markdown
-## Unsafe Code Analysis
-Functions  Expressions  Impls  Traits  Methods  Dependency
-0/10       0/100        0/5    0/2     0/20     rust_template
-
-## Binary Size Analysis
-File   .text   Size    Crate
- 71.0%  59.0%   1.2MiB  std
-  8.5%   7.1%   147KiB  rust_template
-  
-## Documentation Coverage
-Documenting rust_template v0.1.0
-warning: missing documentation for public function
-```
-
-## Configuration
-
-### Unsafe Code Limits
-
-In `Cargo.toml`:
+Set the unsafe policy in `Cargo.toml`:
 
 ```toml
 [lints.rust]
@@ -92,7 +105,9 @@ unsafe_code = "forbid"  # No unsafe allowed
 unsafe_code = "warn"    # Warn but allow
 ```
 
-### Binary Size Optimization
+Verify: `cargo geiger` reports `0/N` for a `forbid` crate.
+
+### Configure binary size optimization
 
 ```toml
 [profile.release]
@@ -103,59 +118,21 @@ strip = true          # Remove symbols
 panic = "abort"       # Smaller panic handler
 ```
 
-### Documentation Requirements
+Verify: `cargo build --release && cargo bloat --release --crates` and compare the total size.
+
+### Configure documentation requirements
 
 ```toml
 [lints.rust]
-missing_docs = "warn"           # Warn on missing docs
+missing_docs = "warn"                     # Warn on missing docs
 rustdoc::broken_intra_doc_links = "deny"  # Fail on broken links
 ```
 
-## Interpreting Results
+Verify: `cargo doc --no-deps` surfaces missing-doc warnings.
 
-### Unsafe Code Report
+### Improve the metrics
 
-```text
-Functions  Expressions  Impls  Traits  Methods  Dependency
-2/10       5/100        0/5    0/2     0/20     ✓ rust_template
-```
-
-- **Functions**: 2 functions contain unsafe code
-- **Expressions**: 5 unsafe expressions total
-- **✓** = No unsafe in this crate's API
-
-**Action:** Review unsafe usage, add safety comments.
-
-### Binary Size Report
-
-```text
-File   .text   Size    Crate
-71.0%  59.0%   1.2MiB  std        ← Standard library
- 8.5%   7.1%   147KiB  rust_template
- 5.2%   4.3%   89KiB   serde
-```
-
-**Action:** Consider `serde` feature flags to reduce size.
-
-### Documentation Coverage
-
-```text
-warning: missing documentation for public function `add`
-  --> crates/lib.rs:10
-```
-
-**Action:** Add doc comments:
-
-```rust
-/// Adds two numbers together.
-pub fn add(a: i64, b: i64) -> i64 {
-    a + b
-}
-```
-
-## Improving Metrics
-
-### Reduce Unsafe Code
+**Reduce unsafe code** — replace raw pointer writes with safe abstractions:
 
 ```rust
 // Before
@@ -167,60 +144,55 @@ unsafe {
 vec[index] = value;
 ```
 
-### Reduce Binary Size
+**Reduce binary size** — find the largest contributors, then enable size optimizations:
 
 ```bash
-# Analyze what's taking space
 cargo bloat --release -n 20
-
-# Enable size optimizations
-[profile.release]
-opt-level = "z"
-strip = true
 ```
 
-### Improve Documentation
+**Improve documentation** — add the missing doc comment the report named:
 
-```bash
-# Check coverage
-cargo doc --no-deps
-
-# Run doc tests
-cargo test --doc
-
-# Generate private docs
-cargo doc --no-deps --document-private-items
+```rust
+/// Adds two numbers together.
+pub fn add(a: i64, b: i64) -> i64 {
+    a + b
+}
 ```
 
-## Troubleshooting
+```bash
+cargo doc --no-deps                          # Check coverage
+cargo test --doc                             # Run doc tests
+cargo doc --no-deps --document-private-items # Generate private docs
+```
 
-### cargo-geiger Errors
+Verify: re-run the relevant tool and confirm the count dropped.
+
+### Troubleshooting
+
+**cargo-geiger errors**:
 
 ```bash
-# Update tool
 cargo install cargo-geiger --force
-
-# Clear cache
 cargo clean
 cargo geiger
 ```
 
-### Binary Size Analysis Fails
+**Binary size analysis fails** — ensure a release build exists first:
 
 ```bash
-# Ensure release build exists
 cargo build --release
-
-# Run bloat
 cargo bloat --release
 ```
 
-### Documentation Warnings
+**Documentation warnings** — surface them all as errors:
 
 ```bash
-# See all warnings
 RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
 ```
+
+## Why this matters
+
+These three metrics each guard a property the compiler alone won't enforce. `unsafe_code = "forbid"` is the template default, so `cargo-geiger` exists to confirm that guarantee holds transitively — unsafe code bypasses Rust's safety model, and a dependency can reintroduce it silently. Binary size matters for download time and memory footprint, and `cargo-bloat` makes the cost of each dependency visible so feature trimming is an informed decision. Documentation coverage is a usability property: a well-documented public API is the difference between a crate people can adopt and one they have to reverse-engineer.
 
 ## Links
 
@@ -228,3 +200,4 @@ RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
 - [cargo-bloat](https://github.com/RazrFalcon/cargo-bloat)
 - [rustdoc Documentation](https://doc.rust-lang.org/rustdoc/)
 - [Unsafe Code Guidelines](https://rust-lang.github.io/unsafe-code-guidelines/)
+- [CI Workflows reference](../template/CI-WORKFLOWS.md)

--- a/docs/workflows/CONTAINER-SCAN.md
+++ b/docs/workflows/CONTAINER-SCAN.md
@@ -1,100 +1,42 @@
+---
+diataxis_type: how-to
+---
 # Container Vulnerability Scanning with Trivy
 
-## Overview
+Automated Docker container vulnerability scanning using [Trivy](https://github.com/aquasecurity/trivy), with findings surfaced in the GitHub Security tab.
 
-Automated Docker container vulnerability scanning using [Trivy](https://github.com/aquasecurity/trivy).
+## Reference
 
-**Workflow:** `.github/workflows/container-scan.yml`  
-**Triggers:** Push, PR, Weekly schedule, Manual  
-**Integration:** GitHub Security tab (SARIF upload)
+Trivy runs via the central reusable `reusable-trivy.yml` (from `zircote/.github`), invoked from two callers:
 
-## How It Works
+| Field | Value |
+|---|---|
+| Filesystem scan | `quality-gates.yml` (job `trivy`) — IaC + license scan over the source tree, at merge time |
+| Image scan | `pipeline.yml` (job `gate-image`) — Trivy image scan, publish-gated (dormant in template state) |
+| Image attestation | `pipeline.yml` (job `attest-container-scan`) — binds the image scan verdict to the image digest as a `container-scan/v1` attestation |
+| Integration | GitHub Security tab (SARIF upload) |
 
-Scans Docker images for:
+### What it scans for
+
+Trivy scans Docker images for:
+
 - OS package vulnerabilities (CVEs)
-- Application dependencies vulnerabilities  
+- Application dependency vulnerabilities
 - Misconfigurations
 - Secrets in image layers
 
-**Severity Levels:**
-- CRITICAL
-- HIGH
-- MEDIUM
-- LOW
-- UNKNOWN
+Severity levels: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `UNKNOWN`.
 
-## Usage
+### CI pipeline stages
 
-### Local Scanning
+Two Trivy lanes run through the central reusable workflow:
 
-```bash
-# Install Trivy
-brew install trivy
-# or
-curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+1. **Filesystem (merge-time)** — `quality-gates.yml` scans the source tree (Dockerfile, manifests, licenses) and uploads SARIF to GitHub Security.
+2. **Image (publish-gated)** — once the container build is armed (`publish = false` deleted), `pipeline.yml`'s `gate-image` job runs a Trivy image scan against the built image digest. The `attest-container-scan` job then signs the scan result and binds it to the image digest as a `container-scan/v1` attestation.
 
-# Build and scan image
-docker build -t rust-template:local .
-trivy image rust-template:local
+Filesystem findings appear in **Security tab → Code scanning alerts**. Image scan findings become a signed `container-scan/v1` attestation on the image (verifiable with `gh attestation verify`).
 
-# Scan specific severity
-trivy image --severity HIGH,CRITICAL rust-template:local
-
-# Output formats
-trivy image --format json rust-template:local > scan.json
-trivy image --format sarif rust-template:local > scan.sarif
-```
-
-### CI Scanning
-
-The workflow automatically:
-1. Builds Docker image
-2. Scans for vulnerabilities
-3. Uploads SARIF to GitHub Security
-4. Generates human-readable report
-5. Uploads report as artifact
-
-**View Results:**
-- Security tab → Code scanning alerts
-- Actions tab → Artifacts → trivy-scan-report
-
-## Configuration
-
-### Severity Threshold
-
-Edit `.github/workflows/container-scan.yml`:
-
-```yaml
-- name: Run Trivy
-  with:
-    severity: CRITICAL,HIGH  # Only critical and high
-```
-
-### Ignore Unfixed
-
-Skip vulnerabilities without fixes:
-
-```yaml
-- name: Run Trivy
-  with:
-    ignore-unfixed: true
-```
-
-### Trivy Configuration File
-
-Create `.trivyignore`:
-
-```text
-# Ignore specific CVEs
-CVE-2021-12345
-
-# Ignore by package
-pkg:deb/debian/openssl@1.1.1
-```
-
-## Understanding Results
-
-### SARIF Output (GitHub Security)
+### SARIF output (GitHub Security)
 
 ```json
 {
@@ -117,7 +59,7 @@ pkg:deb/debian/openssl@1.1.1
 }
 ```
 
-### Table Output
+### Table output
 
 ```text
 Library      Vulnerability  Severity  Status  Installed  Fixed
@@ -125,81 +67,133 @@ Library      Vulnerability  Severity  Status  Installed  Fixed
 openssl      CVE-2021-12345 CRITICAL  fixed   1.1.1k     1.1.1l
 ```
 
-## Remediation
+### Scheduled scans
 
-### Update Base Image
-
-```dockerfile
-# Before
-FROM rust:1.92-slim
-
-# After (with digest for immutability)
-FROM rust:1.92-slim@sha256:abc123...
-```
-
-### Update Dependencies
-
-```bash
-# Update Cargo dependencies
-cargo update
-cargo audit
-
-# Rebuild image
-docker build -t rust-template:patched .
-trivy image rust-template:patched
-```
-
-### Accept Risk
-
-For false positives or accepted risks:
-
-```text
-# .trivyignore
-CVE-2021-12345  # Mitigated by network isolation
-```
-
-## Scheduled Scans
-
-Weekly scans run automatically:
+The filesystem gate in `quality-gates.yml` re-runs weekly on a schedule, so a previously clean tree is re-checked against newly disclosed CVEs:
 
 ```yaml
 schedule:
-  - cron: "0 0 * * 0"  # Every Sunday at midnight
+  - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
 ```
 
-## Troubleshooting
+The image scan in `pipeline.yml` is event-driven (on push/tag once publishing is armed), not scheduled.
 
-### Scan Failures
+## How-to
+
+### Scan locally
 
 ```bash
-# Update Trivy database
-trivy image --download-db-only
+# Install Trivy
+brew install trivy
+# or
+curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
 
-# Clear cache
+# Build and scan image
+docker build -t rust-template:local .
+trivy image rust-template:local
+
+# Scan a specific severity
+trivy image --severity HIGH,CRITICAL rust-template:local
+
+# Output formats
+trivy image --format json rust-template:local > scan.json
+trivy image --format sarif rust-template:local > scan.sarif
+```
+
+Verify: `trivy image rust-template:local` prints a vulnerability table.
+
+### Configure the severity threshold
+
+Trivy behaviour is configured in the central reusable workflow (`zircote/.github`), not in this repo. To adjust severity for a local scan:
+
+```bash
+trivy image --severity CRITICAL,HIGH rust-template:local
+```
+
+Verify: confirm only the selected severities are reported.
+
+### Ignore unfixed vulnerabilities
+
+For a local scan, drop vulnerabilities that have no available fix:
+
+```bash
+trivy image --ignore-unfixed rust-template:local
+```
+
+Verify: vulnerabilities with no available fix no longer appear.
+
+### Suppress specific findings
+
+Create `.trivyignore`:
+
+```text
+# Ignore specific CVEs
+CVE-2021-12345
+
+# Ignore by package
+pkg:deb/debian/openssl@1.1.1
+```
+
+Verify: `trivy image rust-template:local` no longer lists the ignored entries.
+
+### Remediate a finding
+
+1. **Update the base image** (pin by digest for immutability):
+
+   ```dockerfile
+   # Before
+   FROM rust:1.92-slim
+
+   # After (with digest for immutability)
+   FROM rust:1.92-slim@sha256:abc123...
+   ```
+
+2. **Update dependencies and rebuild**:
+
+   ```bash
+   cargo update
+   cargo audit
+   docker build -t rust-template:patched .
+   trivy image rust-template:patched
+   ```
+
+3. **Accept a documented risk** (false positive or mitigated):
+
+   ```text
+   # .trivyignore
+   CVE-2021-12345  # Mitigated by network isolation
+   ```
+
+Verify: re-scan the rebuilt image and confirm the finding is resolved or suppressed.
+
+### Troubleshooting
+
+**Scan failures**:
+
+```bash
+trivy image --download-db-only
 trivy image --clear-cache
 ```
 
-### False Positives
-
-Check vulnerability details:
+**False positives** — inspect the finding, then suppress if confirmed:
 
 ```bash
 trivy image --format json rust-template:local | jq '.Results[].Vulnerabilities[] | select(.VulnerabilityID=="CVE-2021-12345")'
 ```
 
-Add to `.trivyignore` if confirmed false positive.
+**Slow scans**:
 
-### Performance
-
-Scans can be slow. Optimize:
-
-```yaml
+```bash
 # Scan only critical/high
-severity: CRITICAL,HIGH
+trivy image --severity CRITICAL,HIGH rust-template:local
 
-# Skip DB download
-skip-db-update: true  # Use cache
+# Skip DB download (use cache)
+trivy image --skip-db-update rust-template:local
 ```
+
+## Why this matters
+
+A vulnerable dependency or base image is a vulnerability in the shipped artifact, even when the application source is clean. Scanning the built image — not just `Cargo.lock` — catches OS-level CVEs, misconfigurations, and leaked secrets that source-level audits miss. Surfacing the filesystem findings as SARIF in the GitHub Security tab puts them where reviewers already work and gives each one a tracked lifecycle, while the image scan verdict is signed and bound to the image digest as a verifiable attestation. The weekly filesystem schedule re-checks the source against newly disclosed CVEs so a previously clean tree doesn't silently age into a vulnerable one.
 
 ## Links
 
@@ -207,3 +201,4 @@ skip-db-update: true  # Use cache
 - [Configuration Reference](https://aquasecurity.github.io/trivy/latest/docs/configuration/)
 - [CVE Database](https://cve.mitre.org/)
 - [GitHub Security Advisories](https://github.com/advisories)
+- [CI Workflows reference](../template/CI-WORKFLOWS.md)

--- a/docs/workflows/COVERAGE.md
+++ b/docs/workflows/COVERAGE.md
@@ -1,39 +1,96 @@
+---
+diataxis_type: how-to
+---
 # Code Coverage Tracking
 
-## Overview
+Automated code coverage measurement and tracking using [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov), with optional Codecov reporting.
 
-Automated code coverage measurement and tracking using [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov).
+## Reference
 
-**Workflow:** `.github/workflows/ci-coverage.yml`
-**Tool:** cargo-llvm-cov
-**Integration:** Codecov (optional)
-**Triggers:** Push to main, PRs, Weekly schedule
-**Target:** ≥80% coverage
+| Field | Value |
+|---|---|
+| Workflow | `.github/workflows/ci-coverage.yml` |
+| Tool | cargo-llvm-cov |
+| Integration | Codecov (optional) |
+| Triggers | Push to main, PRs, weekly schedule |
+| Target | ≥90% coverage |
 
-## How It Works
+### CI pipeline stages
 
-1. **Instrument**: Compile with coverage instrumentation
-2. **Execute**: Run all tests (unit, integration, doc)
-3. **Collect**: Gather coverage data
-4. **Report**: Generate HTML, LCOV, JSON reports
-5. **Upload**: Send to Codecov (optional)
-6. **Comment**: Post summary on PRs
+The workflow automatically:
 
-## Setup
+1. **Instrument** — compile with coverage instrumentation.
+2. **Execute** — run all tests (unit, integration, doc).
+3. **Collect** — gather coverage data.
+4. **Report** — generate HTML, LCOV, and JSON reports.
+5. **Upload** — send to Codecov (if a token is configured).
+6. **Comment** — post a summary on PRs.
 
-### Install Locally
+Reports are available via **Actions → Workflow Run → Artifacts → coverage-report** (30-day retention) and via an automated PR comment.
+
+### Summary output
+
+```text
+Filename              Regions  Missed Regions  Coverage
+---------------------------------------------------------
+crates/lib.rs              45              3     93.33%
+crates/parser.rs           78             12     84.62%
+crates/utils.rs            23              0    100.00%
+---------------------------------------------------------
+TOTAL                     146             15     89.73%
+```
+
+- **Regions**: code regions (branches, statements).
+- **Missed Regions**: not executed during tests.
+- **Coverage**: percent of regions executed.
+
+### HTML report
+
+Interactive report at `target/llvm-cov/html/index.html`:
+
+- **Green**: covered lines.
+- **Red**: uncovered lines.
+- **Yellow**: partially covered branches.
+
+### Coverage types
+
+1. **Line coverage**: percent of lines executed.
+2. **Branch coverage**: percent of conditional branches taken.
+3. **Function coverage**: percent of functions called.
+
+### Coverage goals
+
+| Coverage | Quality | Action |
+|----------|---------|--------|
+| `< 50%` | Poor ❌ | Critical gaps |
+| `50-70%` | Fair ⚠️ | Needs improvement |
+| `70-85%` | Good ✅ | Acceptable |
+| `> 85%` | Excellent 🌟 | High quality |
+
+**Project target: ≥90%**
+
+### What coverage does not measure
+
+Coverage shows **execution**, not:
+
+- **Correctness**: executed code may still be wrong.
+- **Edge cases**: may miss unusual inputs.
+- **Logic errors**: all branches covered ≠ all cases tested.
+- **Race conditions**: concurrency issues are invisible.
+
+Use coverage alongside mutation testing, property-based testing, and manual review.
+
+## How-to
+
+### Install and generate coverage locally
 
 ```bash
 # Install cargo-llvm-cov
 cargo install cargo-llvm-cov
 
-# Install llvm-tools component
+# Install the llvm-tools component
 rustup component add llvm-tools-preview
-```
 
-### Generate Coverage
-
-```bash
 # Generate coverage for all tests
 cargo llvm-cov
 
@@ -47,175 +104,78 @@ cargo llvm-cov --lcov --output-path lcov.info
 cargo llvm-cov --json --output-path coverage.json
 ```
 
-## Understanding Reports
+Verify: `cargo llvm-cov` prints a `TOTAL` coverage line.
 
-### Summary Output
+### Find and close coverage gaps
 
-```text
-Filename              Regions  Missed Regions  Coverage
----------------------------------------------------------
-crates/lib.rs              45              3     93.33%
-crates/parser.rs           78             12     84.62%
-crates/utils.rs            23              0    100.00%
----------------------------------------------------------
-TOTAL                     146             15     89.73%
-```
+1. Show uncovered lines:
 
-**Metrics:**
-- **Regions**: Code regions (branches, statements)
-- **Missed Regions**: Not executed during tests
-- **Coverage**: % of regions executed
+   ```bash
+   cargo llvm-cov --show-missing-lines
+   cargo llvm-cov --ignore-filename-regex tests/
+   ```
 
-### HTML Report
+2. Add tests for the uncovered branch. For example, this error path is not covered:
 
-Interactive report showing:
-- **Green**: Covered lines
-- **Red**: Uncovered lines
-- **Yellow**: Partially covered branches
+   ```rust
+   pub fn divide(a: i32, b: i32) -> Result<i32, Error> {
+       if b == 0 {
+           return Err(Error::DivideByZero);  // ❌ Not covered
+       }
+       Ok(a / b)  // ✅ Covered
+   }
+   ```
 
-**Access:** `target/llvm-cov/html/index.html`
+   Add the missing error-case test:
 
-### Coverage Types
+   ```rust
+   #[test]
+   fn test_divide_by_zero() {
+       assert!(divide(10, 0).is_err());
+   }
+   ```
 
-1. **Line Coverage**: % of lines executed
-2. **Branch Coverage**: % of conditional branches taken
-3. **Function Coverage**: % of functions called
+3. Cover the common gap categories:
 
-## Coverage Goals
+   ```rust
+   // Error paths
+   #[test]
+   fn test_errors() {
+       assert!(parse("").is_err());
+       assert!(parse("invalid").is_err());
+       assert!(parse("too_long_".repeat(1000).as_str()).is_err());
+   }
 
-| Coverage | Quality | Action |
-|----------|---------|--------|
-| < 50% | Poor ❌ | Critical gaps |
-| 50-70% | Fair ⚠️ | Needs improvement |
-| 70-85% | Good ✅ | Acceptable |
-| > 85% | Excellent 🌟 | High quality |
+   // Edge cases / boundaries
+   #[test]
+   fn test_boundaries() {
+       assert_eq!(clamp(0, 0, 10), 0);     // min
+       assert_eq!(clamp(10, 0, 10), 10);   // max
+       assert_eq!(clamp(-1, 0, 10), 0);    // below min
+       assert_eq!(clamp(11, 0, 10), 10);   // above max
+   }
 
-**Project Target: ≥80%**
+   // Conditional branches — exercise both sides
+   #[test]
+   fn test_both_branches() {
+       assert!(process(b"valid", true).is_ok());
+       assert!(process(b"data", false).is_ok());
+   }
+   ```
 
-## Improving Coverage
+   For `match` expressions, ensure every arm is exercised by a test.
 
-### Identify Gaps
+Verify: re-run `cargo llvm-cov` and confirm the coverage percentage increased.
 
-```bash
-# Show uncovered lines
-cargo llvm-cov --show-missing-lines
-
-# Focus on specific file
-cargo llvm-cov --ignore-filename-regex tests/
-```
-
-### Example: Uncovered Code
-
-**Code:**
-```rust
-pub fn divide(a: i32, b: i32) -> Result<i32, Error> {
-    if b == 0 {
-        return Err(Error::DivideByZero);  // ❌ Not covered
-    }
-    Ok(a / b)  // ✅ Covered
-}
-```
-
-**Test (Incomplete):**
-```rust
-#[test]
-fn test_divide() {
-    assert_eq!(divide(10, 2).unwrap(), 5);
-    // Missing: error case!
-}
-```
-
-**Fix: Add Error Test**
-```rust
-#[test]
-fn test_divide_by_zero() {
-    assert!(divide(10, 0).is_err());
-}
-```
-
-### Common Gaps
-
-#### 1. Error Paths
-
-```rust
-// Add tests for all error branches
-#[test]
-fn test_errors() {
-    assert!(parse("").is_err());
-    assert!(parse("invalid").is_err());
-    assert!(parse("too_long_".repeat(1000).as_str()).is_err());
-}
-```
-
-#### 2. Edge Cases
-
-```rust
-// Test boundaries
-#[test]
-fn test_boundaries() {
-    assert_eq!(clamp(0, 0, 10), 0);     // min
-    assert_eq!(clamp(10, 0, 10), 10);   // max
-    assert_eq!(clamp(-1, 0, 10), 0);    // below min
-    assert_eq!(clamp(11, 0, 10), 10);   // above max
-}
-```
-
-#### 3. Conditional Branches
-
-```rust
-pub fn process(data: &[u8], validate: bool) -> Result<Output> {
-    if validate {
-        check_validity(data)?;  // Branch 1
-    }
-    // Branch 2
-    parse(data)
-}
-
-#[test]
-fn test_both_branches() {
-    // Test with validation
-    assert!(process(b"valid", true).is_ok());
-    // Test without validation
-    assert!(process(b"data", false).is_ok());
-}
-```
-
-#### 4. Match Arms
-
-```rust
-match status {
-    Status::Ready => handle_ready(),      // Test
-    Status::Pending => handle_pending(),  // Test
-    Status::Error(_) => handle_error(),   // Test
-}
-```
-
-## Configuration
-
-### Exclude Files
+### Configure coverage
 
 ```bash
-# Ignore test files
+# Exclude test files
 cargo llvm-cov --ignore-filename-regex tests/
 
-# Ignore generated code
+# Exclude generated code
 cargo llvm-cov --ignore-filename-regex generated/
-```
 
-### Coverage Threshold
-
-```bash
-# Fail if below 80%
-coverage=$(cargo llvm-cov --summary-only | grep -oP 'TOTAL.*\K\d+\.\d+')
-if (( $(echo "$coverage < 80" | bc -l) )); then
-    echo "Coverage ${coverage}% below threshold 80%"
-    exit 1
-fi
-```
-
-### Feature Flags
-
-```bash
 # Coverage with all features
 cargo llvm-cov --all-features
 
@@ -223,159 +183,58 @@ cargo llvm-cov --all-features
 cargo llvm-cov --features feature1,feature2
 ```
 
-## Codecov Integration
-
-### Setup
-
-1. **Sign up**: https://codecov.io/
-2. **Add repository**: GitHub integration
-3. **Get token**: Settings → Repository Upload Token
-4. **Add secret**: GitHub repo → Settings → Secrets → `CODECOV_TOKEN`
-
-### Upload
+Enforce a local threshold:
 
 ```bash
-# Generate LCOV
-cargo llvm-cov --lcov --output-path lcov.info
-
-# Upload to Codecov
-bash <(curl -s https://codecov.io/bash) -f lcov.info
+coverage=$(cargo llvm-cov --summary-only | grep -oP 'TOTAL.*\K\d+\.\d+')
+if (( $(echo "$coverage < 90" | bc -l) )); then
+    echo "Coverage ${coverage}% below threshold 90%"
+    exit 1
+fi
 ```
 
-**CI Integration:** Automatic via workflow.
+Verify: the script exits non-zero when coverage drops below the threshold.
 
-### Codecov Features
+### Set up Codecov
 
-- **PR Comments**: Coverage diff on PRs
-- **Trends**: Coverage over time
-- **Badges**: Display in README
-- **Sunburst**: Visual coverage map
+1. Sign up at https://codecov.io/.
+2. Add the repository (GitHub integration).
+3. Get the token: **Settings → Repository Upload Token**.
+4. Add the secret: **GitHub repo → Settings → Secrets → `CODECOV_TOKEN`**.
+5. Upload (CI does this automatically; manual command below):
 
-### Badge
+   ```bash
+   cargo llvm-cov --lcov --output-path lcov.info
+   bash <(curl -s https://codecov.io/bash) -f lcov.info
+   ```
 
-Add to `README.md`:
+Codecov then provides PR coverage diffs, trend tracking, a README badge, and a sunburst map. Add the badge to `README.md`:
 
 ```markdown
 [![codecov](https://codecov.io/gh/USER/REPO/branch/main/graph/badge.svg)](https://codecov.io/gh/USER/REPO)
 ```
 
-## Advanced Usage
+Verify: the Codecov dashboard shows the uploaded report.
 
-### Differential Coverage
+### Advanced usage
 
 ```bash
-# Coverage for changed files only (in PR)
+# Coverage for changed files only (in a PR)
 git diff --name-only main | grep '\.rs$' | xargs cargo llvm-cov --include-ffi
-```
 
-### Profiling Hot Spots
-
-```bash
 # Generate profdata for analysis
 cargo llvm-cov --no-report --profdata-output rust_template.profdata
-
-# Analyze with llvm-profdata
 llvm-profdata show rust_template.profdata
-```
 
-### Doc Test Coverage
-
-```bash
 # Include documentation tests
 cargo llvm-cov --doc
-```
 
-### Workspace Coverage
-
-```bash
-# Coverage across workspace
+# Coverage across a workspace
 cargo llvm-cov --workspace
-
-# Exclude workspace members
 cargo llvm-cov --workspace --exclude member1
 ```
 
-## CI Workflow Details
-
-### What It Does
-
-1. Runs all tests with instrumentation
-2. Generates HTML, LCOV, JSON reports
-3. Uploads to Codecov (if token configured)
-4. Comments PR with summary
-5. Uploads artifacts (30-day retention)
-
-### Access Reports
-
-**In CI:**
-- Actions → Workflow Run → Artifacts → coverage-report
-
-**In PR:**
-- Automated comment with coverage %
-
-## Troubleshooting
-
-### Zero Coverage
-
-```bash
-# Ensure llvm-tools installed
-rustup component add llvm-tools-preview
-
-# Clean and rebuild
-cargo clean
-cargo llvm-cov
-```
-
-### Incomplete Coverage
-
-```bash
-# Include all test types
-cargo llvm-cov --all-targets
-
-# Include doc tests
-cargo llvm-cov --doc
-```
-
-### Slow Coverage
-
-```bash
-# Parallel execution
-cargo llvm-cov -- --test-threads=4
-
-# Skip slow tests
-cargo llvm-cov -- --skip slow_test
-```
-
-### Codecov Upload Fails
-
-```bash
-# Check token
-echo $CODECOV_TOKEN
-
-# Manual upload with verbose
-bash <(curl -s https://codecov.io/bash) -f lcov.info -v
-```
-
-## Best Practices
-
-1. **Aim for ≥80%** - Good balance of quality and effort
-2. **Test error paths** - Don't just test happy path
-3. **Exclude test code** - Focus on production code
-4. **Use integration tests** - Cover real usage patterns
-5. **Track trends** - Coverage should improve over time
-6. **Don't game metrics** - Meaningful tests > coverage %
-
-## What Coverage Doesn't Measure
-
-Coverage shows **execution**, not:
-- **Correctness**: Executed code may still be wrong
-- **Edge cases**: May miss unusual inputs
-- **Logic errors**: All branches covered ≠ all cases tested
-- **Race conditions**: Concurrency issues invisible
-
-**Use with:** Mutation testing, property-based testing, manual review.
-
-## Ignoring Code
+### Exclude code from coverage
 
 ```rust
 // Ignore unreachable safety invariants
@@ -391,9 +250,55 @@ fn debug_only_function() {
 }
 ```
 
+### Troubleshooting
+
+**Zero coverage**:
+
+```bash
+rustup component add llvm-tools-preview
+cargo clean
+cargo llvm-cov
+```
+
+**Incomplete coverage**:
+
+```bash
+cargo llvm-cov --all-targets
+cargo llvm-cov --doc
+```
+
+**Slow coverage**:
+
+```bash
+cargo llvm-cov -- --test-threads=4
+cargo llvm-cov -- --skip slow_test
+```
+
+**Codecov upload fails**:
+
+```bash
+echo $CODECOV_TOKEN
+bash <(curl -s https://codecov.io/bash) -f lcov.info -v
+```
+
+### Best practices
+
+1. **Aim for ≥90%** — a good balance of quality and effort.
+2. **Test error paths** — don't just test the happy path.
+3. **Exclude test code** — focus on production code.
+4. **Use integration tests** — cover real usage patterns.
+5. **Track trends** — coverage should improve over time.
+6. **Don't game metrics** — meaningful tests beat a coverage number.
+
+## Why this matters
+
+Coverage answers exactly one question: which lines ran during the tests. That is necessary but not sufficient — code that never executes is certainly untested, but executed code with a weak assertion is also effectively untested. That is why the target sits at ≥90% rather than 100%: the last few percent are usually unreachable error branches or defensive code where the cost of contrived tests outweighs the value, and chasing the number invites assertion-free tests that inflate coverage without catching bugs. The honest use of coverage is as a gap-finder feeding real tests, paired with mutation and property testing to check whether those tests actually assert anything.
+
 ## Links
 
 - [cargo-llvm-cov Documentation](https://github.com/taiki-e/cargo-llvm-cov)
 - [Codecov Documentation](https://docs.codecov.com/)
 - [LLVM Coverage Mapping](https://llvm.org/docs/CoverageMappingFormat.html)
 - [Coverage Best Practices](https://testing.googleblog.com/2020/08/code-coverage-best-practices.html)
+- [Mutation Testing](MUTATION-TESTING.md)
+- [CI Workflows reference](../template/CI-WORKFLOWS.md)

--- a/docs/workflows/COVERAGE.md
+++ b/docs/workflows/COVERAGE.md
@@ -12,7 +12,7 @@ Automated code coverage measurement and tracking using [cargo-llvm-cov](https://
 | Workflow | `.github/workflows/ci-coverage.yml` |
 | Tool | cargo-llvm-cov |
 | Integration | Codecov (optional) |
-| Triggers | Push to main, PRs, weekly schedule |
+| Triggers | Via `pipeline.yml` on push/PR/tag, plus manual (`workflow_dispatch`) |
 | Target | ≥90% coverage |
 
 ### CI pipeline stages
@@ -23,10 +23,10 @@ The workflow automatically:
 2. **Execute** — run all tests (unit, integration, doc).
 3. **Collect** — gather coverage data.
 4. **Report** — generate HTML, LCOV, and JSON reports.
-5. **Upload** — send to Codecov (if a token is configured).
-6. **Comment** — post a summary on PRs.
+5. **Upload** — send to Codecov (if a token is configured) and upload the `coverage-report` artifact.
+6. **Enforce** — fail CI if total coverage is below the 90% threshold.
 
-Reports are available via **Actions → Workflow Run → Artifacts → coverage-report** (30-day retention) and via an automated PR comment.
+Reports are available via **Actions → Workflow Run → Artifacts → coverage-report** (30-day retention).
 
 ### Summary output
 

--- a/docs/workflows/FUZZ-TESTING.md
+++ b/docs/workflows/FUZZ-TESTING.md
@@ -11,7 +11,7 @@ Automated fuzz testing to discover crashes, panics, and edge cases using [cargo-
 |---|---|
 | Workflow | `.github/workflows/fuzz-testing.yml` |
 | Tool | `cargo-fuzz` (libFuzzer) |
-| Schedule | Daily at 2 AM |
+| Trigger | Manual (`workflow_dispatch`); a daily cron is present but commented out |
 | Goal | Find unexpected inputs that cause crashes |
 
 ### How fuzzing works
@@ -28,9 +28,10 @@ The fuzzer generates random or mutated inputs and feeds them to a target functio
 
 The workflow runs:
 
-- **Daily** at 2 AM (scheduled).
-- **On demand** via workflow dispatch.
+- **On demand** via `workflow_dispatch` (the only active trigger).
 - **Duration:** 5 minutes per target (configurable).
+
+A daily `schedule:` cron (`0 2 * * *`) is present in the workflow but commented out. Uncomment the `schedule:` block in `.github/workflows/fuzz-testing.yml` to run fuzzing daily.
 
 On a crash it creates a GitHub issue and uploads crash artifacts (90-day retention).
 
@@ -323,7 +324,7 @@ rm -rf fuzz/corpus/target/*
 
 ## Why this matters
 
-Hand-written tests check the inputs a developer thought of; fuzzing checks the inputs nobody thought of. By mutating inputs toward new code coverage, a fuzzer drives execution into the malformed, adversarial, and boundary cases where parsers, decoders, and deserializers actually break. Because it runs unattended and saves any crash as a minimized, replayable artifact, fuzzing turns "we hope this handles bad input" into a reproducible bug report — and the daily schedule keeps probing as the code evolves, catching regressions long-running campaigns would otherwise surface only by luck.
+Hand-written tests check the inputs a developer thought of; fuzzing checks the inputs nobody thought of. By mutating inputs toward new code coverage, a fuzzer drives execution into the malformed, adversarial, and boundary cases where parsers, decoders, and deserializers actually break. Because it runs unattended and saves any crash as a minimized, replayable artifact, fuzzing turns "we hope this handles bad input" into a reproducible bug report — and enabling the (commented-out) daily schedule keeps probing as the code evolves, catching regressions long-running campaigns would otherwise surface only by luck.
 
 ## Links
 

--- a/docs/workflows/FUZZ-TESTING.md
+++ b/docs/workflows/FUZZ-TESTING.md
@@ -1,29 +1,80 @@
+---
+diataxis_type: how-to
+---
 # Fuzz Testing with cargo-fuzz
-
-## Overview
 
 Automated fuzz testing to discover crashes, panics, and edge cases using [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz).
 
-**Workflow:** `.github/workflows/fuzz-testing.yml`
-**Tool:** `cargo-fuzz` (libFuzzer)
-**Schedule:** Daily at 2 AM
-**Goal:** Find unexpected inputs that cause crashes
+## Reference
 
-## How It Works
+| Field | Value |
+|---|---|
+| Workflow | `.github/workflows/fuzz-testing.yml` |
+| Tool | `cargo-fuzz` (libFuzzer) |
+| Schedule | Daily at 2 AM |
+| Goal | Find unexpected inputs that cause crashes |
 
-Fuzz testing generates random/mutated inputs and feeds them to your code:
+### How fuzzing works
 
-1. **Generate Inputs**: Create random or mutated test inputs
-2. **Execute**: Run target function with inputs
-3. **Monitor**: Detect crashes, panics, timeouts, memory errors
-4. **Minimize**: Reduce crashing inputs to minimal reproducible cases
-5. **Report**: Save crash artifacts for investigation
+The fuzzer generates random or mutated inputs and feeds them to a target function:
 
-**Fuzzing finds bugs traditional testing misses.**
+1. **Generate inputs** — create random or mutated test inputs.
+2. **Execute** — run the target function with each input.
+3. **Monitor** — detect crashes, panics, timeouts, and memory errors.
+4. **Minimize** — reduce a crashing input to a minimal reproducible case.
+5. **Report** — save crash artifacts for investigation.
 
-## Setup
+### CI behavior
 
-### Initialize Fuzz Directory
+The workflow runs:
+
+- **Daily** at 2 AM (scheduled).
+- **On demand** via workflow dispatch.
+- **Duration:** 5 minutes per target (configurable).
+
+On a crash it creates a GitHub issue and uploads crash artifacts (90-day retention).
+
+### Successful run output (no crashes)
+
+```text
+#0  READ units: 1234
+#1  pulse  cov: 234 ft: 456 corp: 10/1234b
+...
+Done 10000 runs in 300 seconds
+```
+
+- **units**: inputs tested.
+- **cov**: code coverage.
+- **ft**: features covered.
+- **corp**: corpus size.
+
+### Crash output
+
+```text
+==1234==ERROR: AddressSanitizer: heap-buffer-overflow
+READ of size 1 at 0x...
+```
+
+The crashing input is saved to `fuzz/artifacts/<target>/crash-<hash>`.
+
+### Corpus layout
+
+```text
+fuzz/corpus/parse_input/
+├── 0a1b2c3d4e5f...  # Auto-generated interesting cases
+├── 1b2c3d4e5f6a...
+└── seed_inputs/     # Your seed corpus
+```
+
+The fuzzer automatically saves interesting inputs that reach new coverage.
+
+### Security benefits
+
+Fuzz testing finds buffer overflows, integer overflows, assertion failures, panics and unwraps, memory leaks, and logic errors triggered by edge-case inputs.
+
+## How-to
+
+### Initialize fuzzing
 
 ```bash
 # Install cargo-fuzz (requires nightly Rust)
@@ -31,17 +82,22 @@ cargo install cargo-fuzz
 
 # Initialize fuzz targets
 cargo fuzz init
-
-# Directory structure:
-# fuzz/
-# ├── Cargo.toml
-# └── fuzz_targets/
-#     └── fuzz_target_1.rs
 ```
 
-### Create Fuzz Target
+This creates:
 
-**Example: `fuzz/fuzz_targets/parse_input.rs`**
+```text
+fuzz/
+├── Cargo.toml
+└── fuzz_targets/
+    └── fuzz_target_1.rs
+```
+
+Verify: `cargo fuzz list` prints the generated target.
+
+### Create a fuzz target
+
+Write `fuzz/fuzz_targets/parse_input.rs`:
 
 ```rust
 #![no_main]
@@ -58,9 +114,7 @@ fuzz_target!(|data: &[u8]| {
 });
 ```
 
-### Structured Fuzzing
-
-For structured data, use `arbitrary`:
+For structured input, derive `Arbitrary`:
 
 ```rust
 #![no_main]
@@ -81,123 +135,115 @@ fuzz_target!(|input: FuzzInput| {
 });
 ```
 
-## Usage
+Verify: `cargo fuzz list` shows the new target.
 
-### Local Fuzzing
+### Run fuzzing locally
 
 ```bash
 # List fuzz targets
 cargo fuzz list
 
-# Run specific target for 60 seconds
+# Run a target for 60 seconds
 cargo fuzz run parse_input -- -max_total_time=60
 
-# Run with more jobs (parallel)
+# Run with more parallel jobs
 cargo fuzz run parse_input -- -jobs=4
 
-# Run with corpus (saved inputs)
+# Run against a saved corpus
 cargo fuzz run parse_input fuzz/corpus/parse_input
 ```
 
-### CI Integration
+Verify: the run prints `cov:`/`corp:` lines and ends with `Done N runs`.
 
-The workflow runs automatically:
-- **Daily** at 2 AM (scheduled)
-- **Manual** via workflow dispatch
-- **Duration:** 5 minutes per target (configurable)
+### Investigate a crash
 
-**Crash Detection:**
-- Creates GitHub issue if crashes found
-- Uploads crash artifacts (90-day retention)
+1. Reproduce with the saved artifact:
 
-## Understanding Results
+   ```bash
+   cargo fuzz run parse_input fuzz/artifacts/parse_input/crash-*
+   ```
 
-### Successful Run (No Crashes)
+2. Minimize the crashing input:
+
+   ```bash
+   cargo fuzz tmin parse_input crash_artifact
+   ```
+
+3. Add debug output to the target if needed:
+
+   ```rust
+   fuzz_target!(|data: &[u8]| {
+       eprintln!("Input length: {}", data.len());
+       if let Ok(s) = std::str::from_utf8(data) {
+           eprintln!("Input: {:?}", s);
+           let _ = parse(s);
+       }
+   });
+   ```
+
+Verify: re-running with the minimized artifact still reproduces the crash, then fix the bug and confirm it no longer does.
+
+### Manage the corpus
+
+Seed initial inputs in `fuzz/corpus/<target>/`:
+
+```bash
+mkdir -p fuzz/corpus/parse_input
+echo "valid input" > fuzz/corpus/parse_input/valid1
+echo "" > fuzz/corpus/parse_input/empty
+echo "🦀" > fuzz/corpus/parse_input/unicode
+```
+
+Verify: `cargo fuzz run parse_input fuzz/corpus/parse_input` loads the seeds.
+
+### Configure fuzzing
+
+```yaml
+# In the workflow — adjust per-target duration
+duration: '600'  # 10 minutes
+```
+
+```bash
+# Limit memory usage
+cargo fuzz run target -- -rss_limit_mb=2048
+```
+
+Add a dictionary of domain keywords at `fuzz/dict/target.dict`:
 
 ```text
-#0  READ units: 1234
-#1  pulse  cov: 234 ft: 456 corp: 10/1234b
-...
-Done 10000 runs in 300 seconds
+"keyword1"
+"keyword2"
+"special_token"
 ```
-
-- **units**: Inputs tested
-- **cov**: Code coverage
-- **ft**: Features covered
-- **corp**: Corpus size
-
-### Crash Detected
-
-```text
-==1234==ERROR: AddressSanitizer: heap-buffer-overflow
-READ of size 1 at 0x...
-```
-
-**Artifact saved:** `fuzz/artifacts/parse_input/crash-da39a3ee5e6b4b0d3255bfef95601890afd80709`
-
-**Reproduce:**
-```bash
-cargo fuzz run parse_input fuzz/artifacts/parse_input/crash-*
-```
-
-## Crash Investigation
-
-### Reproduce Crash
 
 ```bash
-# Run with specific crash input
-cargo fuzz run target_name crash_artifact
+cargo fuzz run target -- -dict=fuzz/dict/target.dict
 ```
 
-### Minimize Crash Input
+Verify: the run reports the dictionary loaded.
 
-```bash
-# Reduce to minimal crashing input
-cargo fuzz tmin target_name crash_artifact
-```
-
-### Debug
+### Common fuzz target patterns
 
 ```rust
-// Add to fuzz target for debugging
-fuzz_target!(|data: &[u8]| {
-    eprintln!("Input length: {}", data.len());
-    if let Ok(s) = std::str::from_utf8(data) {
-        eprintln!("Input: {:?}", s);
-        let _ = parse(s);
-    }
-});
-```
-
-## Common Fuzz Targets
-
-### 1. Parsers
-
-```rust
+// Parsers
 fuzz_target!(|data: &[u8]| {
     if let Ok(s) = std::str::from_utf8(data) {
         let _ = parser::parse(s);
     }
 });
-```
 
-### 2. Deserialization
-
-```rust
+// Deserialization
 fuzz_target!(|data: &[u8]| {
     let _: Result<MyStruct, _> = serde_json::from_slice(data);
 });
-```
 
-### 3. Binary Protocols
-
-```rust
+// Binary protocols
 fuzz_target!(|data: &[u8]| {
     let _ = decode_packet(data);
 });
 ```
 
-### 4. State Machines
+State machines via a sequence of arbitrary actions:
 
 ```rust
 #[derive(Arbitrary, Debug)]
@@ -215,110 +261,7 @@ fuzz_target!(|actions: Vec<Action>| {
 });
 ```
 
-## Corpus Management
-
-### Seed Corpus
-
-Create initial inputs in `fuzz/corpus/target_name/`:
-
-```bash
-mkdir -p fuzz/corpus/parse_input
-echo "valid input" > fuzz/corpus/parse_input/valid1
-echo "" > fuzz/corpus/parse_input/empty
-echo "🦀" > fuzz/corpus/parse_input/unicode
-```
-
-### Corpus Growth
-
-Fuzzer automatically saves interesting inputs:
-
-```text
-fuzz/corpus/parse_input/
-├── 0a1b2c3d4e5f...  # Auto-generated interesting cases
-├── 1b2c3d4e5f6a...
-└── seed_inputs/     # Your seed corpus
-```
-
-## Configuration
-
-### Adjust Timeout
-
-```yaml
-# In workflow
-duration: '600'  # 10 minutes
-```
-
-### Memory Limits
-
-```bash
-# Limit memory usage
-cargo fuzz run target -- -rss_limit_mb=2048
-```
-
-### Dictionary
-
-Create `fuzz/dict/target.dict` for domain-specific keywords:
-
-```text
-"keyword1"
-"keyword2"
-"special_token"
-```
-
-```bash
-cargo fuzz run target -- -dict=fuzz/dict/target.dict
-```
-
-## Troubleshooting
-
-### Slow Fuzzing
-
-```bash
-# Run with more jobs
-cargo fuzz run target -- -jobs=8
-
-# Reduce input size
-cargo fuzz run target -- -max_len=1024
-```
-
-### Out of Memory
-
-```bash
-# Limit RSS
-cargo fuzz run target -- -rss_limit_mb=2048
-
-# Reduce corpus
-rm -rf fuzz/corpus/target/*
-```
-
-### No New Coverage
-
-Fuzzer might be stuck. Try:
-
-1. **Better seed corpus**: Add diverse initial inputs
-2. **Dictionary**: Add domain keywords
-3. **Structured fuzzing**: Use `arbitrary` for complex inputs
-
-## Best Practices
-
-1. **Start simple**: Fuzz one function at a time
-2. **Use seed corpus**: Guide fuzzer with valid examples
-3. **Run long sessions**: Hours or days, not minutes
-4. **Minimize crashes**: Use `cargo fuzz tmin` for debugging
-5. **Continuous fuzzing**: Run in CI regularly
-6. **Multiple targets**: Fuzz different entry points
-
-## Security Benefits
-
-Fuzz testing finds:
-- Buffer overflows
-- Integer overflows
-- Assertion failures
-- Panics and unwraps
-- Memory leaks
-- Logic errors with edge cases
-
-## Example: Complete Fuzz Target
+A complete structured target with input constraints:
 
 ```rust
 #![no_main]
@@ -351,9 +294,41 @@ fn process_request(config: &Config) -> Result<(), Error> {
 }
 ```
 
+### Troubleshooting
+
+**Slow fuzzing**:
+
+```bash
+cargo fuzz run target -- -jobs=8
+cargo fuzz run target -- -max_len=1024
+```
+
+**Out of memory**:
+
+```bash
+cargo fuzz run target -- -rss_limit_mb=2048
+rm -rf fuzz/corpus/target/*
+```
+
+**No new coverage** — the fuzzer may be stuck. Add a better seed corpus, a dictionary, or switch to structured fuzzing with `arbitrary`.
+
+### Best practices
+
+1. **Start simple** — fuzz one function at a time.
+2. **Use a seed corpus** — guide the fuzzer with valid examples.
+3. **Run long sessions** — hours or days, not minutes.
+4. **Minimize crashes** — use `cargo fuzz tmin` for debugging.
+5. **Fuzz continuously** — run in CI regularly.
+6. **Fuzz multiple targets** — cover different entry points.
+
+## Why this matters
+
+Hand-written tests check the inputs a developer thought of; fuzzing checks the inputs nobody thought of. By mutating inputs toward new code coverage, a fuzzer drives execution into the malformed, adversarial, and boundary cases where parsers, decoders, and deserializers actually break. Because it runs unattended and saves any crash as a minimized, replayable artifact, fuzzing turns "we hope this handles bad input" into a reproducible bug report — and the daily schedule keeps probing as the code evolves, catching regressions long-running campaigns would otherwise surface only by luck.
+
 ## Links
 
 - [cargo-fuzz Book](https://rust-fuzz.github.io/book/)
 - [libFuzzer Documentation](https://llvm.org/docs/LibFuzzer.html)
 - [Arbitrary Crate](https://docs.rs/arbitrary/)
 - [Fuzzing Rust Code](https://rust-fuzz.github.io/book/introduction.html)
+- [CI Workflows reference](../template/CI-WORKFLOWS.md)

--- a/docs/workflows/MUTATION-TESTING.md
+++ b/docs/workflows/MUTATION-TESTING.md
@@ -11,7 +11,7 @@ Automated mutation testing to validate test suite effectiveness using [cargo-mut
 |---|---|
 | Workflow | `.github/workflows/mutation-testing.yml` |
 | Tool | `cargo-mutants` |
-| Triggers | PR (on src/tests changes), manual dispatch |
+| Triggers | PR (on `crates/`/`tests/` changes), manual dispatch |
 | Goal | Detect weak or missing tests |
 
 ### How mutation testing works
@@ -35,7 +35,7 @@ Good tests catch mutants; a surviving (missed) mutant marks a test gap.
 
 ### CI behavior
 
-The workflow runs automatically on PRs when `src/` or `tests/` change, and posts results as a PR comment. Reports are also available via **Actions → Artifacts → mutation-test-report**.
+The workflow runs automatically on PRs when `crates/`, `tests/`, `Cargo.toml`, or `Cargo.lock` change. It uploads the `mutation-test-report` artifact, available via **Actions → Artifacts → mutation-test-report**.
 
 ### Summary output
 
@@ -236,7 +236,7 @@ cargo mutants --timeout 600
 
 ## Why this matters
 
-Line coverage tells you a line ran; it cannot tell you whether a test would notice if that line were wrong. Mutation testing closes exactly that blind spot — by deliberately breaking the code and checking whether any test fails, it distinguishes assertions that verify behavior from tests that merely execute it. A high coverage number paired with a low mutation score is the signature of tautological tests, and surfacing that gap on PRs (where `src/` or `tests/` changed) keeps test quality from quietly decaying as the codebase grows.
+Line coverage tells you a line ran; it cannot tell you whether a test would notice if that line were wrong. Mutation testing closes exactly that blind spot — by deliberately breaking the code and checking whether any test fails, it distinguishes assertions that verify behavior from tests that merely execute it. A high coverage number paired with a low mutation score is the signature of tautological tests, and surfacing that gap on PRs (where `crates/` or `tests/` changed) keeps test quality from quietly decaying as the codebase grows.
 
 ## Links
 

--- a/docs/workflows/MUTATION-TESTING.md
+++ b/docs/workflows/MUTATION-TESTING.md
@@ -1,65 +1,43 @@
+---
+diataxis_type: how-to
+---
 # Mutation Testing with cargo-mutants
 
-## Overview
+Automated mutation testing to validate test suite effectiveness using [cargo-mutants](https://github.com/sourcefrog/cargo-mutants) — it measures whether your tests actually catch bugs, not just whether they run.
 
-Automated mutation testing to validate test suite effectiveness using [cargo-mutants](https://github.com/sourcefrog/cargo-mutants).
+## Reference
 
-**Workflow:** `.github/workflows/mutation-testing.yml`
-**Tool:** `cargo-mutants`
-**Triggers:** PR (on src/tests changes), Manual dispatch
-**Goal:** Detect weak or missing tests
+| Field | Value |
+|---|---|
+| Workflow | `.github/workflows/mutation-testing.yml` |
+| Tool | `cargo-mutants` |
+| Triggers | PR (on src/tests changes), manual dispatch |
+| Goal | Detect weak or missing tests |
 
-## How It Works
+### How mutation testing works
 
-Mutation testing modifies your code (introduces "mutants") and runs tests to see if they catch the changes:
+cargo-mutants modifies your code (introduces "mutants") and runs the test suite against each change:
 
-1. **Generate Mutants**: Modify code in systematic ways (e.g., change `+` to `-`, `>` to `<`)
-2. **Run Tests**: Execute test suite against each mutant
-3. **Score**: % of mutants caught by tests = test quality score
+1. **Generate mutants** — modify code systematically (e.g. `+` to `-`, `>` to `<`).
+2. **Run tests** — execute the suite against each mutant.
+3. **Score** — the percentage of mutants caught by tests is the test-quality score.
 
-**Good tests catch mutants. Missed mutants = test gaps.**
+Good tests catch mutants; a surviving (missed) mutant marks a test gap.
 
-## Mutation Types
+### Mutation types
 
-cargo-mutants generates these mutations:
+| Category | Example |
+|---|---|
+| Binary operators | `+` → `-`, `*` → `/`, `&&` → `\|\|` |
+| Comparison operators | `>` → `<`, `==` → `!=` |
+| Return values | Return a default instead of the computed value |
+| Function bodies | Replace with a default/empty implementation |
 
-- **Binary operators**: `+` → `-`, `*` → `/`, `&&` → `||`
-- **Comparison operators**: `>` → `<`, `==` → `!=`
-- **Return values**: Return default value instead of computed value
-- **Function bodies**: Replace with default/empty implementation
+### CI behavior
 
-## Usage
+The workflow runs automatically on PRs when `src/` or `tests/` change, and posts results as a PR comment. Reports are also available via **Actions → Artifacts → mutation-test-report**.
 
-### Local Testing
-
-```bash
-# Install cargo-mutants
-cargo install cargo-mutants
-
-# Run mutation tests
-cargo mutants
-
-# Test specific file
-cargo mutants --file crates/lib.rs
-
-# Limit execution time
-cargo mutants --timeout 300
-
-# Generate JSON output
-cargo mutants --output mutants.out --json
-```
-
-### CI Integration
-
-The workflow runs automatically on PRs when `src/` or `tests/` change. Results posted as PR comment.
-
-**View Results:**
-- PR comments (automatic)
-- Actions → Artifacts → mutation-test-report
-
-## Understanding Results
-
-### Summary Output
+### Summary output
 
 ```text
 Total mutants: 50
@@ -69,15 +47,15 @@ Timeout: 0
 Score: 90%
 ```
 
-- **Total**: Number of mutations generated
-- **Caught**: Mutations detected by tests (good!)
-- **Missed**: Mutations not caught (test gaps)
-- **Timeout**: Mutations causing infinite loops
-- **Score**: `(caught / total) * 100`
+- **Total**: mutations generated.
+- **Caught**: mutations detected by tests (good).
+- **Missed**: mutations not caught (test gaps).
+- **Timeout**: mutations causing infinite loops.
+- **Score**: `(caught / total) * 100`.
 
-**Target: ≥80% mutation score**
+**Target: ≥80% mutation score.**
 
-### Missed Mutants Report
+### Missed mutant report
 
 ```text
 Function: calculate_total
@@ -88,20 +66,57 @@ Status: MISSED
 This mutant survived testing, indicating missing test coverage.
 ```
 
-**Action:** Add test case that would fail if `+` became `-`.
+### Score interpretation
 
-## Improving Mutation Score
+| Score | Quality |
+|---|---|
+| `< 50%` | Critical test gaps |
+| `50-80%` | Needs improvement |
+| `≥80%` | Good coverage |
+| `≥95%` | Excellent coverage |
 
-### Example: Missed Mutant
+### Why mutants survive
 
-**Original Code:**
+1. **Missing tests** — the function is not tested at all.
+2. **Weak assertions** — tests don't verify actual behavior.
+3. **Dead code** — code that never executes (remove it).
+4. **Equivalent mutants** — the mutation doesn't change behavior (rare).
+
+## How-to
+
+### Run mutation tests locally
+
+```bash
+# Install cargo-mutants
+cargo install cargo-mutants
+
+# Run mutation tests
+cargo mutants
+
+# Test a specific file
+cargo mutants --file crates/lib.rs
+
+# Limit execution time
+cargo mutants --timeout 300
+
+# Generate JSON output
+cargo mutants --output mutants.out --json
+```
+
+Verify: the run prints a `Score:` line.
+
+### Close a missed mutant
+
+A weak test lets a mutant survive. Given:
+
 ```rust
 pub fn add(a: i32, b: i32) -> i32 {
     a + b
 }
 ```
 
-**Test (Inadequate):**
+this test passes even when `+` becomes `-` (`2 - 2 = 0`, but the assertion only checks `add(2, 2)`):
+
 ```rust
 #[test]
 fn test_add() {
@@ -109,10 +124,8 @@ fn test_add() {
 }
 ```
 
-**Mutant:** `a + b` → `a - b`
-**Result:** Test passes with `2 - 2 = 0` (wrong!)
+Add cases that distinguish the operators:
 
-**Fix: Add More Test Cases**
 ```rust
 #[test]
 fn test_add() {
@@ -122,46 +135,36 @@ fn test_add() {
 }
 ```
 
-### Common Patterns
-
-#### 1. Test Edge Cases
+Cover the recurring gap categories:
 
 ```rust
-// Catch comparison mutations
+// Catch comparison mutations with boundary values
 #[test]
 fn test_bounds() {
     assert!(is_valid(0));    // boundary
     assert!(is_valid(100));  // boundary
     assert!(!is_valid(101)); // just outside
 }
-```
 
-#### 2. Test Error Paths
-
-```rust
-// Ensure error conditions are tested
+// Catch missing error-path tests
 #[test]
 fn test_error() {
     assert!(parse("").is_err());
     assert!(parse("invalid").is_err());
 }
-```
 
-#### 3. Test Return Values
-
-```rust
-// Don't just check success, verify values
+// Catch return-value mutations — assert the value, not just success
 #[test]
 fn test_compute() {
     assert_eq!(compute(5), 25);  // Not just assert!(compute(5) > 0)
 }
 ```
 
-## Configuration
+Verify: re-run `cargo mutants --file <file>` and confirm the mutant is now caught.
 
-### Exclude Files
+### Configure cargo-mutants
 
-Create `.cargo-mutants.toml`:
+Exclude files in `.cargo-mutants.toml`:
 
 ```toml
 [mutants]
@@ -171,56 +174,23 @@ exclude_files = [
 ]
 ```
 
-### Timeouts
+Set a per-mutant timeout in the workflow:
 
 ```yaml
-# In workflow
 cargo mutants --timeout 300  # 5 minutes per mutant
 ```
 
-### Target Specific Functions
+Target specific functions:
 
 ```bash
-# Test only changed functions
 cargo mutants --file crates/lib.rs --re "fn calculate"
 ```
 
-## Interpreting Low Scores
+Verify: `cargo mutants` runs only over the configured scope.
 
-**Score < 50%**: Critical test gaps
-**Score 50-80%**: Needs improvement
-**Score ≥80%**: Good coverage
-**Score ≥95%**: Excellent coverage
+### Skip equivalent mutants
 
-### Why Mutants Survive
-
-1. **Missing tests**: Function not tested at all
-2. **Weak assertions**: Tests don't verify actual behavior
-3. **Dead code**: Code that never executes (remove it)
-4. **Equivalent mutants**: Mutation doesn't change behavior (rare)
-
-## Troubleshooting
-
-### Too Slow
-
-```bash
-# Run in parallel
-cargo mutants --jobs 4
-
-# Test changed files only
-cargo mutants --file crates/changed_file.rs
-```
-
-### Timeouts
-
-```bash
-# Increase timeout for slow tests
-cargo mutants --timeout 600
-```
-
-### False Positives
-
-Some mutants are equivalent (don't change behavior):
+Some mutants don't change behavior and will always survive:
 
 ```rust
 // These are equivalent
@@ -228,17 +198,7 @@ fn example() -> bool { true }
 fn example() -> bool { return true; }
 ```
 
-**Action:** Accept these or skip with `#[mutants::skip]`.
-
-## Best Practices
-
-1. **Run locally** before pushing to catch issues early
-2. **Focus on critical paths** first (public API, core logic)
-3. **Don't chase 100%** - diminishing returns above 90%
-4. **Use with coverage** - mutation testing complements code coverage
-5. **Add tests incrementally** - fix one missed mutant at a time
-
-## Skipping Mutations
+Skip a function the analyzer can't reason about:
 
 ```rust
 #[mutants::skip]  // Skip entire function
@@ -247,8 +207,41 @@ pub fn generated_code() -> i32 {
 }
 ```
 
+Verify: the skipped function no longer appears in the mutant list.
+
+### Troubleshooting
+
+**Too slow**:
+
+```bash
+cargo mutants --jobs 4
+cargo mutants --file crates/changed_file.rs
+```
+
+**Timeouts**:
+
+```bash
+cargo mutants --timeout 600
+```
+
+**False positives** — equivalent mutants; accept them or annotate with `#[mutants::skip]`.
+
+### Best practices
+
+1. **Run locally** before pushing to catch gaps early.
+2. **Focus on critical paths** first (public API, core logic).
+3. **Don't chase 100%** — diminishing returns above 90%.
+4. **Use with coverage** — mutation testing complements line coverage.
+5. **Fix incrementally** — one missed mutant at a time.
+
+## Why this matters
+
+Line coverage tells you a line ran; it cannot tell you whether a test would notice if that line were wrong. Mutation testing closes exactly that blind spot — by deliberately breaking the code and checking whether any test fails, it distinguishes assertions that verify behavior from tests that merely execute it. A high coverage number paired with a low mutation score is the signature of tautological tests, and surfacing that gap on PRs (where `src/` or `tests/` changed) keeps test quality from quietly decaying as the codebase grows.
+
 ## Links
 
 - [cargo-mutants Documentation](https://mutants.rs/)
 - [Mutation Testing Overview](https://en.wikipedia.org/wiki/Mutation_testing)
 - [Best Practices Guide](https://mutants.rs/guide.html)
+- [Coverage](COVERAGE.md)
+- [CI Workflows reference](../template/CI-WORKFLOWS.md)

--- a/docs/workflows/SBOM.md
+++ b/docs/workflows/SBOM.md
@@ -1,152 +1,153 @@
+---
+diataxis_type: how-to
+---
 # Software Bill of Materials (SBOM)
 
-## Overview
+Automated generation of a Software Bill of Materials in CycloneDX format for supply chain transparency and compliance.
 
-Automated generation of Software Bill of Materials in SPDX format for supply chain transparency and compliance.
+## Reference
 
-**Workflow:** `.github/workflows/sbom.yml`  
-**Tool:** `cargo-sbom`  
-**Format:** SPDX 2.3 JSON  
-**Triggers:** Version tags, releases
+| Field | Value |
+|---|---|
+| Workflow | `.github/workflows/release.yml` (job `sbom`) |
+| Tool | `anchore/sbom-action` |
+| Format | CycloneDX JSON |
+| Triggers | Version tags, `workflow_dispatch` dry-run |
 
-## What is an SBOM?
+### What an SBOM is
 
 A machine-readable inventory of:
+
 - All dependencies (direct and transitive)
 - License information
 - Package versions
 - Supplier information
 
-**Use cases:**
-- Supply chain security (EO 14028 compliance)
-- Vulnerability tracking
-- License compliance
-- Dependency auditing
+Common uses: supply chain security (EO 14028 compliance), vulnerability tracking, license compliance, and dependency auditing.
 
-## How It Works
+### CI pipeline stages
 
-On every release:
-1. Generates SBOM from `Cargo.lock`
-2. Outputs SPDX 2.3 JSON format
-3. Uploads as build artifact (90 days)
-4. Attaches to GitHub release
+During a release the `sbom` job in `release.yml`:
 
-## Usage
+1. Downloads the built platform binaries.
+2. Generates a CycloneDX JSON SBOM with `anchore/sbom-action` (output `${bin}-${version}-sbom.cdx.json`).
+3. Attests the SBOM with `actions/attest-sbom`, binding every binary to the SBOM.
+4. Uploads it as a build artifact and attaches it to the GitHub release.
 
-### Generate Locally
-
-```bash
-# Install cargo-sbom
-cargo install cargo-sbom
-
-# Generate SBOM (SPDX format)
-cargo sbom --output-format spdx_json_2_3 > sbom.json
-
-# View SBOM
-cat sbom.json | jq '.packages[] | {name, version, licenseConcluded}'
-```
-
-### Access from Release
-
-```bash
-# Download from GitHub release
-wget https://github.com/zircote/rust-template/releases/download/v0.1.0/sbom-spdx.json
-
-# Analyze with SBOM tools
-sbom-tool validate sbom-spdx.json
-```
-
-## Configuration
-
-The workflow uses default configuration. To customize:
-
-```bash
-# Different output format
-cargo sbom --output-format cyclonedx_json_1_4
-
-# Include build dependencies
-cargo sbom --cargo-features all-features
-```
-
-## SBOM Contents
-
-The generated SBOM includes:
+### SBOM contents
 
 ```json
 {
-  "SPDXID": "SPDXRef-DOCUMENT",
-  "packages": [
-    {
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "metadata": {
+    "component": {
+      "type": "application",
       "name": "rust_template",
-      "versionInfo": "0.1.0",
-      "licenseConcluded": "MIT",
-      "supplier": "Organization: zircote"
+      "version": "0.1.0"
     }
-  ],
-  "relationships": [
+  },
+  "components": [
     {
-      "spdxElementId": "SPDXRef-rust_template",
-      "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-dependency"
+      "type": "library",
+      "name": "serde",
+      "version": "1.0.0",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "purl": "pkg:cargo/serde@1.0.0"
     }
   ]
 }
 ```
 
-## Compliance
+### Compliance coverage
 
-### Executive Order 14028
+- **Executive Order 14028** — machine-readable format (CycloneDX; SPDX also acceptable to regulators), dependency enumeration, license identification, supplier information.
+- **NIST SP 800-161r1** — supply chain risk management.
 
-The SBOM meets requirements for:
-- Machine-readable format (SPDX)
-- Dependency enumeration
-- License identification
-- Supplier information
+## How-to
 
-### NIST Guidelines
+### Generate an SBOM locally
 
-Complies with NIST SP 800-161r1 for supply chain risk management.
-
-## Troubleshooting
-
-### Missing Dependencies
-
-If dependencies are missing:
+The CI job uses `anchore/sbom-action`, which wraps Syft. The local equivalent is `syft` directly (or `cargo cyclonedx` for a Cargo-native CycloneDX document):
 
 ```bash
-# Ensure Cargo.lock is up to date
-cargo update
-cargo sbom --output-format spdx_json_2_3
+# Install syft (the engine behind anchore/sbom-action)
+curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
+# Generate a CycloneDX JSON SBOM
+syft dir:. -o cyclonedx-json > sbom.cdx.json
+
+# View SBOM
+cat sbom.cdx.json | jq '.components[] | {name, version, licenses}'
 ```
 
-### License Issues
+Alternatively, a Cargo-native CycloneDX generator:
 
-Unknown licenses appear as `NOASSERTION`. To fix:
+```bash
+cargo install cargo-cyclonedx
+cargo cyclonedx --format json
+```
+
+Verify: `sbom.cdx.json` parses as JSON and lists component entries.
+
+### Download an SBOM from a release
+
+```bash
+# Download from a GitHub release
+wget https://github.com/zircote/rust-template/releases/download/v0.1.0/rust_template-0.1.0-sbom.cdx.json
+
+# Validate with a CycloneDX-aware tool
+cyclonedx validate --input-file rust_template-0.1.0-sbom.cdx.json
+```
+
+Verify: the validator reports the document as valid.
+
+### Customize generation
+
+```bash
+# SPDX JSON output (also accepted by regulators)
+syft dir:. -o spdx-json
+
+# Restrict to a single artifact
+syft dir:. -o cyclonedx-json --select-catalogers cargo
+```
+
+Verify: the output header reflects the requested format.
+
+### Troubleshooting
+
+**Missing dependencies** — refresh the lockfile first:
+
+```bash
+cargo update
+syft dir:. -o cyclonedx-json
+```
+
+**License issues** — unknown licenses appear blank or as `NOASSERTION`; declare your crate's license in `Cargo.toml`:
 
 ```toml
-# Cargo.toml
 [package]
 license = "MIT"
-
-[dependencies]
-unlicensed-crate = { version = "1.0", license = "MIT" }
 ```
 
-### Format Errors
-
-Validate SBOM:
+**Format errors** — validate the document:
 
 ```bash
-# Install SPDX validator
-pip install spdx-tools
-
-# Validate
-spdx-tools validate sbom-spdx.json
+cyclonedx validate --input-file sbom.cdx.json
 ```
+
+Verify: validation completes without errors.
+
+## Why this matters
+
+An SBOM turns "trust us, the dependencies are fine" into a verifiable artifact. When a new CVE lands against a transitive dependency, the inventory answers "are we affected?" in seconds instead of a manual `cargo tree` audit, and the same document satisfies the machine-readable enumeration that EO 14028 and NIST SP 800-161r1 require. Generating it at release time and attesting it over the shipped binaries binds the bill of materials to exactly the versions that shipped, so the record reflects the released artifact rather than a drifting development tree.
 
 ## Links
 
-- [cargo-sbom Documentation](https://github.com/psastras/sbom-rs)
+- [anchore/sbom-action](https://github.com/anchore/sbom-action)
+- [Syft](https://github.com/anchore/syft)
+- [CycloneDX Specification](https://cyclonedx.org/specification/overview/)
 - [SPDX Specification](https://spdx.github.io/spdx-spec/)
 - [NTIA Minimum Elements](https://www.ntia.gov/files/ntia/publications/sbom_minimum_elements_report.pdf)
 - [Executive Order 14028](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/)
+- [CI Workflows reference](../template/CI-WORKFLOWS.md)

--- a/docs/workflows/SECRETS-SCAN.md
+++ b/docs/workflows/SECRETS-SCAN.md
@@ -1,84 +1,28 @@
+---
+diataxis_type: how-to
+---
 # Secrets Scanning with Gitleaks
 
-## Overview
+Automated secrets detection to prevent credential leaks using [Gitleaks](https://github.com/gitleaks/gitleaks). This scan **fails CI** when a secret is detected.
 
-Automated secrets detection to prevent credential leaks using [Gitleaks](https://github.com/gitleaks/gitleaks).
+## Reference
 
-**Workflow:** `.github/workflows/secrets-scan.yml`  
-**Configuration:** `.gitleaks.toml`  
-**Behavior:** **FAILS CI** if secrets detected  
-**Triggers:** Every push, all pull requests
+| Field | Value |
+|---|---|
+| Workflow | `.github/workflows/secrets-scan.yml` |
+| Configuration | `.gitleaks.toml` |
+| Behavior | **Fails CI** if secrets detected |
+| Triggers | Every push, all pull requests |
 
-## How It Works
+### What it scans
 
-Scans:
 - New commits (on push)
-- All commits in PR branch
+- All commits in the PR branch
 - Files, comments, diffs
 
-Detects:
-- API keys
-- Passwords
-- Tokens (GitHub, AWS, etc.)
-- Private keys
-- Database connection strings
-- Over 100+ secret patterns
+### What it detects
 
-## Configuration
-
-Edit `.gitleaks.toml` to customize:
-
-```toml
-[extend]
-useDefault = true  # Use built-in rules
-
-[allowlist]
-paths = [
-    '''test/fixtures/secrets.txt''',  # Ignore test files
-]
-
-regexes = [
-    '''EXAMPLE_.*''',  # Ignore example placeholders
-]
-```
-
-## Usage
-
-### Local Scanning
-
-```bash
-# Install gitleaks
-brew install gitleaks
-# or
-curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.18.2/gitleaks_8.18.2_linux_x64.tar.gz | tar -xz
-
-# Scan current changes
-gitleaks detect --source . --verbose
-
-# Scan entire history
-gitleaks detect --source . --log-opts="--all"
-
-# Scan specific commit
-gitleaks detect --source . --log-opts="--since=HEAD~1"
-```
-
-### Pre-commit Hook
-
-Prevent secrets from being committed:
-
-```bash
-# .git/hooks/pre-commit
-#!/bin/sh
-gitleaks protect --verbose --redact --staged
-```
-
-```bash
-chmod +x .git/hooks/pre-commit
-```
-
-## What Gets Detected
-
-### Example Patterns
+API keys, passwords, tokens (GitHub, AWS, etc.), private keys, database connection strings, and 100+ built-in secret patterns. Example shapes:
 
 ```text
 # AWS Access Key
@@ -97,82 +41,73 @@ api_key=sk_live_1234567890abcdef
 postgres://user:password@localhost:5432/db
 ```
 
-## Handling Detections
+### Failure output
 
-### False Positives
-
-1. **Add to allowlist** (`.gitleaks.toml`):
-
-```toml
-[allowlist]
-regexes = [
-    '''YOUR_PLACEHOLDER_TOKEN''',
-]
-
-paths = [
-    '''docs/examples/''',
-]
-```
-
-2. **Inline ignore**:
-
-```python
-secret = "not-a-real-secret"  # gitleaks:allow
-```
-
-### True Positives (Leaked Secrets)
-
-**CRITICAL:** If a secret is leaked:
-
-1. **Rotate immediately** - Assume compromised
-2. **Remove from history**:
-   ```bash
-   # Use BFG Repo-Cleaner
-   bfg --replace-text secrets.txt repo.git
-   ```
-3. **Force push** (destructive):
-   ```bash
-   git push --force
-   ```
-
-## CI Integration
-
-The workflow runs on every push and **fails CI** if secrets are found.
-
-**Failure Example:**
 ```text
 Error: gitleaks detected secrets in commits
-Finding: api_key="sk_live_..." 
+Finding: api_key="sk_live_..."
   File: src/config.rs
   Line: 42
   Commit: abc1234
 ```
 
-## Troubleshooting
+## How-to
 
-### Slow Scans
-
-Gitleaks scans git history. For faster scans:
+### Scan locally
 
 ```bash
-# Scan only new commits
-gitleaks protect --staged
+# Install gitleaks
+brew install gitleaks
+# or
+curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.18.2/gitleaks_8.18.2_linux_x64.tar.gz | tar -xz
+
+# Scan current changes
+gitleaks detect --source . --verbose
+
+# Scan entire history
+gitleaks detect --source . --log-opts="--all"
+
+# Scan a specific commit range
+gitleaks detect --source . --log-opts="--since=HEAD~1"
 ```
 
-### Ignoring Files
+Verify: a clean tree reports `no leaks found`.
+
+### Install a pre-commit hook
+
+Block secrets before they are committed:
+
+```bash
+# .git/hooks/pre-commit
+#!/bin/sh
+gitleaks protect --verbose --redact --staged
+```
+
+```bash
+chmod +x .git/hooks/pre-commit
+```
+
+Verify: staging a test secret aborts the commit.
+
+### Configure rules and allowlists
+
+Edit `.gitleaks.toml`:
 
 ```toml
+[extend]
+useDefault = true  # Use built-in rules
+
 [allowlist]
 paths = [
-    '''\.lock$''',       # Lock files
-    '''vendor/''',       # Vendored code  
-    '''test/fixtures/''', # Test data
+    '''test/fixtures/secrets.txt''',  # Ignore test files
+]
+
+regexes = [
+    '''EXAMPLE_.*''',  # Ignore example placeholders
 ]
 ```
 
-### Custom Rules
-
-Add project-specific secret patterns:
+Add project-specific patterns:
 
 ```toml
 [[rules]]
@@ -181,8 +116,77 @@ description = "Project API Key"
 regex = '''project_key_[0-9a-f]{32}'''
 ```
 
+Verify: `gitleaks detect --source .` honors the new rules and allowlists.
+
+### Handle a false positive
+
+1. Add it to the allowlist in `.gitleaks.toml`:
+
+   ```toml
+   [allowlist]
+   regexes = [
+       '''YOUR_PLACEHOLDER_TOKEN''',
+   ]
+
+   paths = [
+       '''docs/examples/''',
+   ]
+   ```
+
+2. Or mark the line inline:
+
+   ```python
+   secret = "not-a-real-secret"  # gitleaks:allow
+   ```
+
+Verify: re-run `gitleaks detect` and confirm the finding is gone.
+
+### Respond to a real leaked secret
+
+**Critical** — if a real secret is detected:
+
+1. **Rotate immediately** — assume the secret is compromised.
+2. **Remove it from history**:
+
+   ```bash
+   # Use BFG Repo-Cleaner
+   bfg --replace-text secrets.txt repo.git
+   ```
+
+3. **Force push** (destructive):
+
+   ```bash
+   git push --force
+   ```
+
+Verify: `gitleaks detect --source . --log-opts="--all"` no longer finds the secret.
+
+### Troubleshooting
+
+**Slow scans** — scan only staged changes:
+
+```bash
+gitleaks protect --staged
+```
+
+**Ignoring files**:
+
+```toml
+[allowlist]
+paths = [
+    '''\.lock$''',        # Lock files
+    '''vendor/''',        # Vendored code
+    '''test/fixtures/''', # Test data
+]
+```
+
+## Why this matters
+
+A leaked credential is one of the fastest paths from a public repository to a compromised system, and once a secret reaches git history it persists in every clone and fork — rotation, not deletion, is the only real fix. Failing CI on detection makes the leak un-mergeable rather than merely flagged, and the pre-commit hook pushes the check earlier still, stopping the secret before it ever enters history where cleanup becomes destructive and incomplete.
+
 ## Links
 
 - [Gitleaks Documentation](https://github.com/gitleaks/gitleaks)
 - [Configuration Guide](https://github.com/gitleaks/gitleaks/tree/master#configuration)
 - [Rule Patterns](https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml)
+- [CI Workflows reference](../template/CI-WORKFLOWS.md)

--- a/docs/workflows/SPELL-CHECK.md
+++ b/docs/workflows/SPELL-CHECK.md
@@ -1,25 +1,51 @@
+---
+diataxis_type: how-to
+---
 # Spell Checking with typos
 
-## Overview
+Automated spell checking for documentation, code comments, and string literals using [typos](https://github.com/crate-ci/typos). It warns on typos but does not fail CI.
 
-Automated spell checking for documentation, code comments, and string literals using [typos](https://github.com/crate-ci/typos).
+## Reference
 
-**Workflow:** `.github/workflows/spell-check.yml`  
-**Configuration:** `.typos.toml`  
-**Behavior:** Warns on typos, does not fail CI
+| Field | Value |
+|---|---|
+| Workflow | `.github/workflows/spell-check.yml` |
+| Configuration | `.typos.toml` |
+| Behavior | Warns on typos, does not fail CI |
 
-## How It Works
+### Triggers
 
-The workflow runs on:
-- Every push to main/master
-- All pull requests
-- Manual workflow dispatch
+The workflow runs on every push to main/master, all pull requests, and manual workflow dispatch. It scans all files (except excluded paths) for common typos and suggests corrections.
 
-It scans all files (except excluded paths) for common typos and suggests corrections.
+### Warning output
 
-## Configuration
+```text
+warning: `recieve` should be `receive`
+  --> crates/lib.rs:10
+```
 
-Edit `.typos.toml` to customize behavior:
+Results are visible in the Actions tab.
+
+## How-to
+
+### Check locally
+
+```bash
+# Install typos
+cargo install typos-cli
+
+# Check for typos
+typos
+
+# Auto-fix typos
+typos --write-changes
+```
+
+Verify: `typos` exits without warnings on clean text.
+
+### Configure behavior
+
+Edit `.typos.toml`:
 
 ```toml
 [default]
@@ -40,43 +66,20 @@ extend-exclude = [
 # "typo" = "correct"
 ```
 
-## Usage
+Verify: `typos` no longer flags the configured patterns.
 
-### Local Check
+### Handle a false positive
 
-```bash
-# Install typos
-cargo install typos-cli
-
-# Check for typos
-typos
-
-# Auto-fix typos
-typos --write-changes
-```
-
-### CI Integration
-
-The workflow runs automatically. Check the Actions tab for results.
-
-**Warning Output:**
-```text
-warning: `recieve` should be `receive`
-  --> crates/lib.rs:10
-```
-
-## Troubleshooting
-
-### False Positives
-
-Add to `.typos.toml`:
+Accept a word as correct:
 
 ```toml
 [default.extend-words]
 myword = "myword"  # Accept as correct
 ```
 
-### Ignore Specific Files
+Verify: re-run `typos` and confirm the word is no longer flagged.
+
+### Exclude specific files
 
 ```toml
 [files]
@@ -85,9 +88,9 @@ extend-exclude = [
 ]
 ```
 
-### Custom Dictionary
+Verify: `typos` skips the excluded paths.
 
-Create a project dictionary:
+### Maintain a custom dictionary
 
 ```toml
 [default.extend-identifiers]
@@ -99,7 +102,14 @@ myvar = "myvar"
 specialterm = "specialterm"
 ```
 
+Verify: `typos` treats the listed identifiers and words as correct.
+
+## Why this matters
+
+Typos in public-facing documentation, API names, and error messages erode trust and make a project look unmaintained, but a hard CI failure on every misspelling would block merges for trivial reasons and tempt contributors to disable the check entirely. Running typos as a non-blocking warning keeps spelling visible on every change without gatekeeping, and the configurable dictionary means domain terms and identifiers are accepted once rather than fought repeatedly.
+
 ## Links
 
 - [typos Documentation](https://github.com/crate-ci/typos)
 - [Configuration Reference](https://github.com/crate-ci/typos/blob/master/docs/reference.md)
+- [CI Workflows reference](../template/CI-WORKFLOWS.md)

--- a/docs/workflows/TEST-MATRIX.md
+++ b/docs/workflows/TEST-MATRIX.md
@@ -1,62 +1,57 @@
+---
+diataxis_type: how-to
+---
 # Test Matrix - Multi-Platform Testing
 
-## Overview
+A comprehensive test matrix validating code across multiple platforms, Rust versions, and feature combinations.
 
-Comprehensive test matrix validating code across multiple platforms, Rust versions, and feature combinations.
+## Reference
 
-**Workflow:** `.github/workflows/test-matrix.yml`
-**Platforms:** Linux, macOS, Windows
-**Rust Versions:** Stable, Beta, Nightly, MSRV (1.80)
-**Triggers:** Push to main, PRs, Weekly schedule
+| Field | Value |
+|---|---|
+| Workflow | `.github/workflows/ci-test-matrix.yml` |
+| Platforms | Linux, macOS, Windows |
+| Rust versions | Stable, Beta, Nightly, MSRV (1.92) |
+| Triggers | Pull requests (via pipeline.yml) |
 
-## Matrix Configuration
+### Operating systems
 
-The workflow tests these combinations:
+- **ubuntu-latest** — Linux (primary platform).
+- **macos-latest** — macOS (Apple Silicon + Intel).
+- **windows-latest** — Windows (x64).
 
-### Operating Systems
-- **ubuntu-latest** - Linux (primary platform)
-- **macos-latest** - macOS (Apple Silicon + Intel)
-- **windows-latest** - Windows (x64)
+### Rust toolchains
 
-### Rust Toolchains
-- **stable** - Latest stable Rust
-- **beta** - Beta channel (upcoming stable)
-- **nightly** - Nightly builds (experimental features)
-- **1.80** - MSRV (Minimum Supported Rust Version)
+- **stable** — latest stable Rust.
+- **beta** — beta channel (upcoming stable).
+- **nightly** — nightly builds (experimental features).
+- **1.92** — MSRV (Minimum Supported Rust Version).
 
-### Feature Combinations
-- `--all-features` - All features enabled
-- `--no-default-features` - Minimal build
-- Default - Standard feature set
+### Feature combinations
 
-**Total Jobs:** ~12-15 (optimized to skip redundant combinations)
+- `--all-features` — all features enabled.
+- `--no-default-features` — minimal build.
+- Default — standard feature set.
 
-## What Gets Tested
+**Total jobs:** ~12-15 (optimized to skip redundant combinations).
 
-### For All Combinations
+### What gets tested
 
-1. **Build**: `cargo build`
-2. **Unit Tests**: `cargo test`
-3. **Doc Tests**: `cargo test --doc`
+| Scope | Checks |
+|---|---|
+| All combinations | `cargo build`, `cargo test`, `cargo test --doc` |
+| Stable + Ubuntu only | `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo doc --no-deps` |
+| Separate jobs | Integration tests (`cargo test --test '*'`), Miri (nightly) |
 
-### Stable + Ubuntu Only
+### Result interpretation
 
-4. **Formatting**: `cargo fmt --check`
-5. **Linting**: `cargo clippy -- -D warnings`
-6. **Documentation**: `cargo doc --no-deps`
+| Result | Meaning | Action |
+|---|---|---|
+| Success ✅ | All platforms and versions pass | Code is portable and compatible |
+| Partial failure ⚠️ | One OS/version fails | Fix the platform-specific issue (path, filesystem, or API difference) |
+| MSRV failure ❌ | MSRV job fails, stable passes | Code uses features newer than MSRV — bump MSRV, remove the feature, or gate it |
 
-### Separate Jobs
-
-7. **Integration Tests**: `cargo test --test '*'`
-8. **Miri**: Undefined behavior detection (nightly)
-
-## Understanding Results
-
-### Success (✅)
-
-All platforms and versions pass. Code is portable and compatible.
-
-### Partial Failure (⚠️)
+Example partial failure:
 
 ```text
 ubuntu-latest / stable: ✅
@@ -64,182 +59,71 @@ macos-latest / stable: ❌
 windows-latest / stable: ✅
 ```
 
-**Action:** Fix macOS-specific issue (likely path, filesystem, or API difference).
-
-### MSRV Failure (❌)
+Example MSRV failure:
 
 ```text
-ubuntu-latest / 1.80: ❌
+ubuntu-latest / 1.92: ❌
 ubuntu-latest / stable: ✅
 ```
 
-**Action:** Code uses features newer than MSRV. Either:
-- Update MSRV in `Cargo.toml`
-- Remove incompatible features
-- Add feature flags
+### Miri coverage
 
-## Platform-Specific Issues
+Miri (nightly only, on a separate job) detects use-after-free, out-of-bounds memory access, data races in unsafe code, invalid pointer arithmetic, and uninitialized memory reads. It is 100-1000x slower than normal tests and does not support file/network I/O.
 
-### Path Separators
+## How-to
 
-```rust
-// ❌ Bad - Unix-only
-let path = format!("{}/file.txt", dir);
+### Check MSRV locally
 
-// ✅ Good - Cross-platform
-use std::path::PathBuf;
-let path = PathBuf::from(dir).join("file.txt");
-```
-
-### Line Endings
-
-```rust
-// ❌ Bad - Assumes Unix line endings
-assert_eq!(content, "line1\nline2\n");
-
-// ✅ Good - Platform-agnostic
-assert_eq!(content.lines().count(), 2);
-```
-
-### Filesystem Case Sensitivity
-
-```rust
-// ❌ Bad - macOS/Windows are case-insensitive
-let file = File::open("Config.toml")?;
-
-// ✅ Good - Exact case matching
-let file = File::open("config.toml")?;
-```
-
-### Process Signals
-
-```rust
-// ❌ Bad - SIGTERM not available on Windows
-std::process::Command::new("kill")
-    .arg("-TERM")
-    .spawn()?;
-
-// ✅ Good - Use cross-platform crate
-use subprocess::Popen;
-```
-
-## MSRV (Minimum Supported Rust Version)
-
-Current MSRV: **1.80**
-
-### Checking MSRV Locally
+Current MSRV: **1.92**.
 
 ```bash
-# Install specific Rust version
-rustup install 1.80
+# Install the MSRV toolchain
+rustup install 1.92
 
 # Test with MSRV
-cargo +1.80 check
-cargo +1.80 test
+cargo +1.92 check
+cargo +1.92 test
 ```
 
-### Common MSRV Issues
+Verify: both commands succeed under the pinned toolchain.
 
-#### Edition Features
-
-```toml
-# Cargo.toml
-[package]
-edition = "2024"  # Requires Rust 1.85+
-rust-version = "1.80"  # Conflict!
-```
-
-**Fix:** Use `edition = "2021"` or update MSRV.
-
-#### Newer APIs
-
-```rust
-// std::io::Read::read_buf() added in 1.78
-let mut buf = Vec::new();
-reader.read_buf(&mut buf)?;
-```
-
-**Fix:** Use older APIs or bump MSRV.
-
-#### Dependency MSRV
-
-```toml
-[dependencies]
-serde = "1.0"  # May require newer Rust
-```
-
-**Fix:** Pin to older compatible versions or update MSRV.
-
-## Feature Testing
-
-### All Features
-
-```yaml
-matrix:
-  features: ['--all-features']
-```
-
-Tests maximum feature combination. Ensures no feature conflicts.
-
-### No Default Features
-
-```yaml
-matrix:
-  features: ['--no-default-features']
-```
-
-Tests minimal build. Ensures optional features don't leak into default.
-
-### Specific Features
+### Test feature combinations locally
 
 ```bash
-# Test individual features locally
+# Individual features
 cargo test --no-default-features --features feature1
 cargo test --no-default-features --features feature2
 cargo test --features feature1,feature2
+
+# Maximum and minimal builds
+cargo test --all-features
+cargo test --no-default-features
 ```
 
-## Integration Tests
+`--all-features` ensures no feature conflicts; `--no-default-features` ensures optional features don't leak into the default set. Verify: every combination compiles and passes.
 
-Separate job runs integration tests:
+### Run integration tests
 
 ```bash
 cargo test --test '*' --verbose
 ```
 
-**Location:** `tests/*.rs`
+Integration tests live in `tests/*.rs` and exercise the public API, not internal units. Verify: all integration tests pass.
 
-**Purpose:** Test public API integration, not internal units.
-
-## Miri - Undefined Behavior Detection
-
-Miri detects:
-- Use-after-free
-- Out-of-bounds memory access
-- Data races (unsafe code)
-- Invalid pointer arithmetic
-- Uninitialized memory reads
-
-### Running Miri Locally
+### Run Miri locally
 
 ```bash
-# Install miri component
+# Install the miri component
 rustup +nightly component add miri
 
 # Run miri tests
 cargo +nightly miri test
 
-# Run specific test
+# Run a specific test
 cargo +nightly miri test test_name
 ```
 
-### Miri Limitations
-
-- **Slow**: 100-1000x slower than normal tests
-- **No I/O**: File/network operations unsupported
-- **Nightly only**: Requires nightly Rust
-
-### Skip Tests in Miri
+Skip a test that does I/O (unsupported under Miri):
 
 ```rust
 #[test]
@@ -249,9 +133,77 @@ fn test_file_io() {
 }
 ```
 
-## Optimization: Reducing CI Time
+Verify: `cargo +nightly miri test` completes with no UB reports.
 
-### Exclude Redundant Combinations
+### Test multiple platforms locally
+
+```bash
+# Cross-compilation with cross
+cargo install cross
+cross test --target x86_64-pc-windows-gnu
+cross test --target x86_64-apple-darwin
+
+# Linux container
+docker run --rm -v $(pwd):/app -w /app rust:latest cargo test
+```
+
+Verify: tests pass for each target you exercise.
+
+### Write portable code
+
+Avoid the common cross-platform pitfalls:
+
+```rust
+// Path separators — use PathBuf, not string formatting
+use std::path::PathBuf;
+let path = PathBuf::from(dir).join("file.txt");
+
+// Line endings — compare structurally, not byte-for-byte
+assert_eq!(content.lines().count(), 2);
+
+// Filesystem case sensitivity — match exact case
+let file = File::open("config.toml")?;
+
+// Process signals — use a cross-platform crate instead of `kill`
+use subprocess::Popen;
+```
+
+Verify: the test matrix passes on all three operating systems.
+
+### Resolve MSRV failures
+
+Common causes and fixes:
+
+```toml
+# Edition vs MSRV conflict
+[package]
+edition = "2024"      # Requires a recent toolchain
+rust-version = "1.92" # Keep these consistent
+```
+
+```rust
+// Newer std APIs may exceed MSRV — use an older API or bump MSRV
+let mut buf = Vec::new();
+reader.read_buf(&mut buf)?;
+```
+
+```toml
+# A dependency may require a newer Rust — pin a compatible version or bump MSRV
+[dependencies]
+serde = "1.0"
+```
+
+Diagnostic steps:
+
+1. Check dependencies: `cargo tree --edges no-dev` for version conflicts.
+2. Check APIs: search for recently stabilized features.
+3. Update or lower MSRV based on the requirement.
+
+Verify: `cargo +1.92 check` succeeds.
+
+### Optimize CI time
+
+Skip redundant combinations:
 
 ```yaml
 matrix:
@@ -262,9 +214,7 @@ matrix:
       rust: beta
 ```
 
-Only test beta on Linux to save time.
-
-### Cache Dependencies
+Cache dependencies:
 
 ```yaml
 - uses: actions/cache@v4
@@ -276,48 +226,19 @@ Only test beta on Linux to save time.
     key: ${{ runner.os }}-${{ matrix.rust }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 ```
 
-Speeds up subsequent runs.
-
-### Fail Fast
+See all failures rather than stopping at the first:
 
 ```yaml
 strategy:
-  fail-fast: false  # Continue all jobs even if one fails
+  fail-fast: false
 ```
 
-See all failures, not just the first.
+Verify: total matrix runtime drops while still covering each platform.
 
-## Local Multi-Platform Testing
+### Troubleshooting
 
-### Using Cross
+**Tests fail only on Windows** — usually path separators (`/` vs `\`), case-insensitive filesystem, a different temp directory, or CRLF vs LF line endings:
 
-```bash
-# Install cross for cross-compilation
-cargo install cross
-
-# Test for different targets
-cross test --target x86_64-pc-windows-gnu
-cross test --target x86_64-apple-darwin
-```
-
-### Docker
-
-```bash
-# Test in Linux container
-docker run --rm -v $(pwd):/app -w /app rust:latest cargo test
-```
-
-## Troubleshooting
-
-### Tests Fail Only on Windows
-
-**Common Causes:**
-- Path separators (`/` vs `\`)
-- Case-insensitive filesystem
-- Different temporary directory location
-- Line endings (CRLF vs LF)
-
-**Debug:**
 ```rust
 #[cfg(windows)]
 #[test]
@@ -326,26 +247,21 @@ fn test_windows_specific() {
 }
 ```
 
-### Tests Fail on macOS Only
+**Tests fail only on macOS** — usually the case-insensitive but case-preserving filesystem, different system APIs, or Apple-specific security restrictions.
 
-**Common Causes:**
-- Case-insensitive but case-preserving filesystem
-- Different system APIs
-- Apple-specific security restrictions
+**MSRV test fails** — check dependency versions, check for recently stabilized APIs, then update or lower MSRV.
 
-### MSRV Test Fails
+### Best practices
 
-1. **Check dependencies**: `cargo tree --edges no-dev` for version conflicts
-2. **Check APIs**: Search for recently stabilized features
-3. **Update or lower MSRV**: Choose based on requirement
+1. **Test locally first** — use `cross` or Docker before pushing.
+2. **Fix MSRV issues early** — don't let them accumulate.
+3. **Use `PathBuf`** — always for cross-platform file paths.
+4. **Gate platform-specific tests** — `#[cfg(target_os = "linux")]`.
+5. **Monitor CI time** — optimize the matrix if jobs run long.
 
-## Best Practices
+## Why this matters
 
-1. **Test locally first**: Use `cross` or Docker before pushing
-2. **Fix MSRV issues early**: Don't let them accumulate
-3. **Use PathBuf**: Always for cross-platform file paths
-4. **Skip platform-specific tests**: Use `#[cfg(target_os = "linux")]`
-5. **Monitor CI time**: Optimize matrix if jobs take too long
+"It works on my machine" is the failure mode this matrix exists to prevent. Rust compiles per target, and behavior diverges on path separators, filesystem case sensitivity, line endings, and platform APIs — bugs that only surface on an OS the author doesn't run. Pinning the MSRV job alongside stable catches the silent dependency on a too-new language feature before downstream users on the supported floor hit it, and the beta/nightly lanes give early warning of upcoming compiler changes while Miri probes for undefined behavior that ordinary tests pass right over.
 
 ## Links
 
@@ -353,3 +269,4 @@ fn test_windows_specific() {
 - [Cross-Compilation](https://rust-lang.github.io/rustup/cross-compilation.html)
 - [Miri Documentation](https://github.com/rust-lang/miri)
 - [GitHub Actions Matrix](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs)
+- [CI Workflows reference](../template/CI-WORKFLOWS.md)

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,40 @@
+//! Basic usage of the `rust_template` example API.
+//!
+//! Run it with:
+//!
+//! ```sh
+//! cargo run --example basic
+//! ```
+//!
+//! NOTE: `add`, `divide`, `process`, and `Config` are placeholder example
+//! API shipped with the template. Replace them with your crate's real
+//! surface — and update this example accordingly.
+
+// Examples demonstrate output, so writing to stdout here is intentional.
+#![allow(clippy::print_stdout)]
+
+use rust_template::{Config, Result, add, divide, process};
+
+fn main() -> Result<()> {
+    // Pure, infallible arithmetic.
+    println!("add(2, 3)     = {}", add(2, 3));
+
+    // Fallible operations return `rust_template::Result`; `?` propagates the
+    // crate's `Error` type.
+    println!("divide(10, 2) = {}", divide(10, 2)?);
+    println!("process(\"42\") = {}", process("42")?);
+
+    // Consuming-self builder: each `with_*` returns `Self`, so calls chain.
+    let config = Config::new()
+        .with_verbose(true)
+        .with_max_retries(5)
+        .with_timeout(30);
+    println!(
+        "config: verbose={}, max_retries={}, timeout_secs={}",
+        config.verbose(),
+        config.max_retries(),
+        config.timeout_secs(),
+    );
+
+    Ok(())
+}

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -54,6 +54,15 @@ export default defineConfig({
                     items: [{ label: "Introduction", slug: "index" }],
                 },
                 {
+                    label: "Tutorials",
+                    items: [
+                        {
+                            label: "Your First Project",
+                            slug: "tutorials/first-project",
+                        },
+                    ],
+                },
+                {
                     label: "Getting Started",
                     items: [
                         {
@@ -124,6 +133,15 @@ export default defineConfig({
                         {
                             label: "Testing",
                             slug: "reference/testing",
+                        },
+                    ],
+                },
+                {
+                    label: "Explanation",
+                    items: [
+                        {
+                            label: "Architecture & Design",
+                            slug: "explanation/architecture",
                         },
                     ],
                 },

--- a/site/scripts/docs-mapping.json
+++ b/site/scripts/docs-mapping.json
@@ -210,6 +210,20 @@
       "title": "ADR-0002: Documentation Directory Structure",
       "description": "Decision on documentation directory organization.",
       "sidebarLabel": "ADR-0002: Doc Structure"
+    },
+    {
+      "source": "docs/tutorials/first-project.md",
+      "output": "tutorials/first-project.mdx",
+      "title": "Your First Project",
+      "description": "A guided, learning-oriented walkthrough from template creation to a green build, a first change, and a first release.",
+      "sidebarLabel": "Your First Project"
+    },
+    {
+      "source": "docs/explanation/architecture.md",
+      "output": "explanation/architecture.mdx",
+      "title": "Architecture & Design",
+      "description": "Why the template is built the way it is: the crates/ layout, CI orchestration, attested delivery, and lint philosophy.",
+      "sidebarLabel": "Architecture & Design"
     }
   ]
 }


### PR DESCRIPTION
Makes the template and its docs world-class by remediating a full Diátaxis audit and filling the gaps it surfaced. (Includes the dormant docs-deploy fix from #95, so this supersedes it.)

## Code
- **examples/basic.rs** — runnable tour of the example API (`cargo run --example basic`).
- **benches/benchmarks.rs** — criterion micro-benchmarks (`add`/`divide`/`process`), wired via `[[bench]] harness=false` so `cargo bench` and `benchmark-regression.yml` are actually meaningful (they were no-ops). criterion added with `default-features = false` to keep the dep tree lean. This also makes AGENTS.md (which referenced `examples/`+`benches/`) accurate.

## Docs (Diátaxis)
- **NEW tutorial** `docs/tutorials/first-project.md` — the missing learning-oriented walkthrough (Use this template → green build → first change → first release), wired into the site sidebar.
- **NEW explanation** `docs/explanation/architecture.md` — consolidated design rationale (crates/ layout, CI orchestration, attested delivery, lint philosophy), wired into the sidebar.
- **`diataxis_type` frontmatter** on every `docs/**/*.md` (the repo's own CLAUDE.md rule, previously unmet by all files).
- **Workflow docs restructured** from mode-mixed → Reference → How-to → Why.
- **Accuracy fixes**: SBOM (CycloneDX via anchore in `release.yml`, not SPDX/`cargo-sbom`/`sbom.yml`), container scan (quality-gates fs + pipeline image, not `container-scan.yml`), coverage threshold 80→90, test-matrix triggers (PRs only).
- **README**: flags the example API as placeholder-to-replace, points newcomers at the tutorial, collapses duplicated release steps to the canonical runbook.
- **Attestation story deduped** (SIGNED-RELEASES canonical).
- Removed the stray `refactor-result-20260319.md` work artifact.

## Verified
crate: build, clippy `--all-targets`, test, `cargo bench --no-run`, `cargo deny`, `cargo run --example basic` all pass. Docs site: `npm run generate` + `astro build` clean (80 pages).
