### PR TITLE
fix(ci): scope Trivy supply-chain scan away from dev-only docs site (539 license alerts)

### DIFF
--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,24 @@
+# Trivy configuration — auto-loaded from the repo root by the Trivy CLI
+# (no --config flag needed). Governs the filesystem scan run by the
+# `trivy` job in .github/workflows/quality-gates.yml, which calls the
+# zircote/.github reusable with scanners=misconfig,license.
+#
+# Why skip `site/`:
+#   `site/` is the Astro documentation site — a private ("private": true),
+#   dev/build-time-only toolchain that is never shipped in the Rust crate or
+#   the container image. Trivy's license scanner walks site/package-lock.json
+#   and emits a license-classification "notice" for every transitive npm
+#   dependency (~540 LOW findings, plus a handful of LGPL "HIGH" from the
+#   `sharp` image-processing native libs). None describe a vulnerability in
+#   the shipped artifact.
+#
+#   License compliance for the shipped crate is governed by `cargo deny check`
+#   against an explicit allowlist (see deny.toml), and the docs site's npm
+#   vulnerabilities are covered by Dependabot — so license-scanning site/ here
+#   is pure noise. This mirrors the OSV/SCA gate, which already scopes itself
+#   to Cargo.lock and excludes site/.
+#
+#   Root-level IaC (the Dockerfile) is still scanned for misconfiguration.
+scan:
+  skip-dirs:
+    - site


### PR DESCRIPTION
## Summary

Adds a repo-root `trivy.yaml` that excludes the `site/` docs toolchain from the Trivy filesystem scan, resolving **539 open code-scanning alerts** (Trivy `License` rule, all `note`/`low`, plus a handful of LGPL `high` from `sharp`).

## Root cause

`quality-gates.yml` calls the `zircote/.github` reusable Trivy workflow with `scanners=misconfig,license` over the whole repo. The license scanner walks `site/package-lock.json` and emits one license-classification *notice* per transitive npm dependency. **All 539 license findings are `site/`-pathed** — none describe a vulnerability in a shipped artifact. (The reusable's `severity: HIGH,CRITICAL` input filters the table/exit-code but not the SARIF upload, so every severity lands in the code-scanning hub.)

## Why this is the right fix, not suppression

`site/` is the Astro documentation site — `"private": true`, dev/build-time only, never shipped in the Rust crate or container image. Its concerns are already covered elsewhere:

- **Shipped-crate licenses** → `cargo deny check` against an explicit allowlist (`deny.toml`).
- **Docs-site npm vulnerabilities** → Dependabot.
- The OSV/SCA gate in the same workflow **already** scopes itself to `Cargo.lock` and excludes `site/` — this change makes the Trivy gate consistent with it.

Root-level IaC (the `Dockerfile`) is **still** scanned for misconfiguration.

## Verification (local Trivy 0.69.3, auto-loading the committed `trivy.yaml`)

```
before:  license=539  misconfig=1
after:   license=0    misconfig=1   (Dockerfile DS-0001 retained)
```

The config is auto-loaded by the Trivy CLI from the working directory (`INFO Loaded file_path="trivy.yaml"`) — no change to the central reusable workflow is required.