### PR TITLE
fix(docker): pin base images by digest + add docker dependabot ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,3 +62,20 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # Docker base images (Dockerfile) — keeps the digest pins fresh.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "docker"
+    reviewers:
+      - "zircote"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 # Build stage
-FROM rust:1.92-slim AS builder
+# Base images are pinned by digest (OpenSSF Scorecard: Pinned-Dependencies).
+# The :tag is kept alongside the digest for human readability; Dependabot's
+# docker ecosystem keeps the digest fresh. Refresh with:
+#   docker buildx imagetools inspect <image> --format '{{.Manifest.Digest}}'
+FROM rust:1.92-slim@sha256:bf3368a992915f128293ac76917ab6e561e4dda883273c8f5c9f6f8ea37a378e AS builder
 
 WORKDIR /app
 
@@ -28,8 +32,10 @@ COPY crates/ ./crates/
 # Build actual binary
 RUN cargo build --release
 
-# Runtime stage - use distroless for minimal attack surface
-FROM gcr.io/distroless/cc-debian12:latest
+# Runtime stage - use distroless for minimal attack surface.
+# Pinned by digest (no :latest) to satisfy Scorecard Pinned-Dependencies and
+# Trivy DS-0001; Dependabot's docker ecosystem keeps the digest fresh.
+FROM gcr.io/distroless/cc-debian12@sha256:d703b626ba455c4e6c6fbe5f36e6f427c85d51445598d564652a2f334179f96e
 
 # Copy binary from builder
 COPY --from=builder /app/target/release/rust_template /usr/local/bin/rust_template


### PR DESCRIPTION
## Summary

Pins both `Dockerfile` base images by digest and adds a `docker` ecosystem to Dependabot so the pins stay fresh. Resolves 3 code-scanning alerts.

| Alert | Severity | Location | Fix |
|---|---|---|---|
| Trivy `DS-0001` | Medium | Dockerfile:32 | dropped `:latest`, pinned by digest |
| Scorecard `Pinned-Dependencies` | Medium | Dockerfile:2 | `rust:1.92-slim@sha256:bf3368a9…` |
| Scorecard `Pinned-Dependencies` | Medium | Dockerfile:32 | `gcr.io/distroless/cc-debian12@sha256:d703b626…` |

## Details

- Both digests are the **multi-arch OCI index** digests, so the existing buildx multi-platform build resolves the correct per-platform image.
- The runtime image drops `:latest` entirely and pins by digest — this satisfies DS-0001 (which fires on `:latest`) and Pinned-Dependencies together. The builder keeps its specific `1.92-slim` tag alongside the digest for readability.
- **`docker` Dependabot ecosystem added** so the digests are refreshed automatically. Pinning without a refresh mechanism would only trade an *unpinned* finding for a *stale base image* risk — the ecosystem makes it a clean win.

## Verification

```
trivy config Dockerfile   → 0 misconfigurations (DS-0001 cleared)
dependabot.yml ecosystems → cargo, github-actions, docker (valid YAML)
```