### PR TITLE
fix(ci): harden Actions token permissions to least privilege (Scorecard)

### DIFF
--- a/.github/workflows/adr-viewer.yml
+++ b/.github/workflows/adr-viewer.yml
@@ -8,10 +8,11 @@ name: ADR Viewer
       - 'docs/adr/**'
   workflow_dispatch:
 
+# Read-only: the job generates ADR HTML and uploads it as an artifact. It
+# does not commit or deploy to Pages (Pages deployment is documented but not
+# implemented here), so no write scopes are needed.
 permissions:
-  contents: write
-  pages: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: "pages"

--- a/.github/workflows/benchmark-regression.yml
+++ b/.github/workflows/benchmark-regression.yml
@@ -5,8 +5,10 @@ on:
     branches: [main, master]
   workflow_dispatch:
 
+# Read-only: the job runs benchmarks and uploads an artifact; it never
+# commits, pushes, or comments back to the repo or PR.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   benchmark:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,8 +8,10 @@ name: Benchmark
     branches: [main, master]
   workflow_dispatch:
 
+# Read-only: the job runs `cargo bench` and uploads an artifact; it never
+# commits, pushes, or stores results back to the repo.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   benchmark:

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -5,13 +5,17 @@ on:
   #   - cron: '0 0 1 * *'  # Monthly on 1st
   workflow_dispatch:
 
+# Least privilege: read-all at the top; the job is granted contents:write
+# only because it commits the regenerated CONTRIBUTORS.md back to the repo.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   update-contributors:
     name: Update Contributors List
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     
     steps:
       - name: Checkout code

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -3,6 +3,10 @@ name: "Copilot Setup Steps"
 
 "on": workflow_dispatch
 
+# Least privilege: this workflow only provisions a build environment.
+permissions:
+  contents: read
+
 jobs:
   copilot-setup-steps:
     name: Copilot coding agent environment

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -5,14 +5,18 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Least privilege: read-all at the top; the auto-merge job is granted write
+# only because it enables auto-merge on Dependabot PRs.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   auto-merge:
     name: Auto-merge Dependabot PRs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     if: github.actor == 'dependabot[bot]'
     
     steps:

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -9,14 +9,18 @@ on:
   #     - 'v*'
   workflow_dispatch:
 
+# Least privilege: read-all at the top; the publish job is granted
+# packages:write only because it pushes images to GHCR.
 permissions:
   contents: read
-  packages: write
 
 jobs:
   docker-publish:
     name: Publish to Multiple Registries
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     
     steps:
       - name: Checkout code

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,13 +6,17 @@ on:
   #   - cron: '0 2 * * *'  # 2 AM daily
   workflow_dispatch:
 
+# Least privilege: read-all at the top; the nightly job is granted
+# contents:write only because it publishes a GitHub Release.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   nightly:
     name: Build Nightly Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     
     steps:
       - name: Checkout code

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -26,12 +26,12 @@ concurrency:
     && github.sha || github.ref }}
   cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
+# Least privilege at the top: read-only. Every job that needs a write scope
+# (packages for the docker push, id-token/attestations for signing,
+# security-events for SARIF) declares it at the job level below.
 permissions:
   contents: read
-  packages: write
-  id-token: write
   actions: read
-  pull-requests: write
 
 jobs:
   # -----------------------------------------------------------
@@ -124,6 +124,10 @@ jobs:
   docker:
     name: Docker
     needs: [ci, gate]
+    # packages:write only here — the reusable pushes the image to GHCR.
+    permissions:
+      contents: read
+      packages: write
     # Container build is gated on template state: skipped while
     # `publish = false` (template), armed once that line is deleted.
     if: >-

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -26,14 +26,18 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+# Least privilege: read-all at the top; the build-and-push job is granted
+# packages:write only because it pushes the image to GHCR (when push=true).
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build-and-push:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}
     steps:

--- a/.github/workflows/template-init.yml
+++ b/.github/workflows/template-init.yml
@@ -9,13 +9,17 @@ name: Template Init
     branches: [main]
   workflow_dispatch:
 
+# Least privilege: read-all at the top; the init job is granted contents:write
+# only because it commits the de-templated files back to the new repo.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   init:
     name: Initialize from template
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: github.repository != 'zircote/rust-template'
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Brings every workflow flagged by OpenSSF Scorecard's **Token-Permissions** check to the least-privilege pattern already used by `release.yml` (read-all top-level; write scopes only on the job that needs them).

## Two classes of fix

**1. Unused write scopes removed → alert clears outright**

| Workflow | Was | Now | Why |
|---|---|---|---|
| `benchmark.yml` | `contents: write` | `contents: read` | only `cargo bench` + upload-artifact |
| `benchmark-regression.yml` | `contents: write` | `contents: read` | only benchmarks + upload-artifact |
| `adr-viewer.yml` | `contents/pages/id-token: write` | `contents: read` | only generates HTML + uploads artifact (no commit, no Pages deploy) |
| `copilot-setup-steps.yml` | *(none defined)* | `contents: read` | only provisions a build env |

**2. Needed writes moved from top-level → owning job (least privilege)**

`template-init` (git push), `nightly` (gh release), `contributors` (git push), `dependabot-automerge` (gh pr merge), `docker-hub` / `release-docker` (`packages: write` push), and `pipeline` (`packages: write` scoped to the `docker` job; redundant top-level `id-token`/`packages`/`pull-requests` writes dropped — already declared on the sign/verify/attest jobs).

Closes the `TokenPermissionsID` code-scanning alerts on these 11 workflows (top-level over-permission). 

## Note on the irreducible remainder

Scorecard emits a Token-Permissions result for **every** `write` scope, even when correctly job-scoped — `release.yml` (the model here) still shows job-level `contents`/`security-events` writes for release creation and SARIF upload. Those are required for the job's function; this PR makes them minimal and documented, matching that model. The irreducible job-level-write alerts are enumerated in the resolution report for dismissal-with-reason.

## Verification

```
actionlint   → no new findings (one pre-existing SC2129 style nit, untouched)
YAML parse   → all 11 files valid
```
No behavior change: every job retains exactly the scopes it exercises (verified each demoted job declares its job-level write; pipeline retains 3 job-level id-token:write on sign/verify/attest).