### PR TITLE
fix(ci): use npm ci for reproducible docs-site install (Scorecard Pinned-Dependencies)

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -52,7 +52,11 @@ jobs:
 
       - name: Install site dependencies
         working-directory: site
-        run: npm ci || npm install
+        # `npm ci` installs strictly from the committed package-lock.json
+        # (pinned, reproducible). The `|| npm install` fallback allowed an
+        # unpinned resolution (Scorecard: Pinned-Dependencies); the lockfile
+        # is committed, so `npm ci` is the correct, reproducible path.
+        run: npm ci
 
       - name: Generate content
         working-directory: site


### PR DESCRIPTION
## Summary

Resolves 1 code-scanning alert by making the docs-site dependency install strictly reproducible.

| Alert | Severity | Location |
|---|---|---|
| Scorecard `Pinned-Dependencies` (npmCommand) | Medium | `docs-deploy.yml:56` |

## Change

```diff
- run: npm ci || npm install
+ run: npm ci
```

The `|| npm install` fallback allowed an **unpinned** dependency resolution whenever `package-lock.json` and `package.json` drifted — exactly what Scorecard's Pinned-Dependencies check flags. `site/package-lock.json` is committed, so `npm ci` (install strictly from the lockfile, fail on drift) is the correct reproducible path.

## Verification

```
YAML parse → valid
```
No `uses:` references changed (no action-SHA pinning needed).