### PR TITLE
feat(fuzz): add minimal cargo-fuzz harness for process()

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target/
+corpus/
+artifacts/
+coverage/

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+# cargo-fuzz harness crate. Standalone (its own [workspace]) because it builds
+# on the nightly toolchain with libFuzzer instrumentation, independent of the
+# parent crate's stable build. Run with: cargo +nightly fuzz run process
+[package]
+name = "rust_template-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.rust_template]
+path = ".."
+
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "process"
+path = "fuzz_targets/process.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/process.rs
+++ b/fuzz/fuzz_targets/process.rs
@@ -1,0 +1,15 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+// Fuzz the public `process` parser. It takes an untrusted `&str`, which makes
+// it the natural fuzz surface for this crate. The harness drives it with
+// arbitrary bytes and asserts the documented contract: `process` never panics,
+// and on success it always returns a non-negative value.
+fuzz_target!(|data: &[u8]| {
+    if let Ok(input) = std::str::from_utf8(data) {
+        if let Ok(value) = rust_template::process(input) {
+            assert!(value >= 0, "process({input:?}) returned a negative value: {value}");
+        }
+    }
+});


### PR DESCRIPTION
## Summary

Adds a minimal cargo-fuzz harness so the repo has a runnable fuzz target — addresses code-scanning **#28 FuzzingID** (Scorecard credits a detectable cargo-fuzz/libfuzzer setup).

## What

- `fuzz/` — standalone crate (own `[workspace]`, `libfuzzer-sys = "0.4"`, path-dep on the parent), so it builds on nightly with libFuzzer instrumentation independent of the stable crate. Not a workspace member → does **not** affect `cargo build/clippy/deny` on the main crate.
- `fuzz/fuzz_targets/process.rs` — one target on the public `process(&str)` parser (the natural untrusted-input surface). Asserts the documented contract: never panics, and on success returns a non-negative value.
- `fuzz/.gitignore` — ignores `target/ corpus/ artifacts/ coverage/`.

The existing `fuzz-testing.yml` already runs `cargo fuzz run` over `fuzz/fuzz_targets/*.rs` (cargo-fuzz 0.12.0, manual/scheduled dispatch); this just gives it a target. There is **no reusable fuzz workflow** in `zircote/.github`, so the standalone workflow is the mechanism.

## Verification

```
cargo +nightly fuzz build process → compiles + links clean (libfuzzer-sys 0.4.13)
```

No change to the public crate API or to the main crate's dependencies (fuzz deps live only in the separate `fuzz/` crate).