### PR TITLE
fix(docs): set Astro base path so GitHub Pages assets resolve

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -64,9 +64,10 @@ jobs:
 
       - name: Build Astro site
         working-directory: site
-        run: |
-          npx astro build \
-            --site https://zircote.github.io/rust-template
+        # site + base come from astro.config.mjs. Do not pass --site here:
+        # overriding it with a path segment double-counts against `base` and
+        # breaks asset URLs.
+        run: npx astro build
 
       - name: Embed rustdoc
         run: |

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -3,7 +3,12 @@ import starlight from "@astrojs/starlight";
 import astroMermaid from "astro-mermaid";
 
 export default defineConfig({
-    site: "https://zircote.github.io/rust-template",
+    // `site` is the deployment ORIGIN; `base` is the path the project is
+    // served under (GitHub Pages serves project sites at <domain>/<repo>).
+    // Without `base`, assets emit at /_astro/... and 404 under /rust-template/,
+    // rendering the site unstyled. With it, they resolve at /rust-template/_astro/.
+    site: "https://zircote.com",
+    base: "/rust-template",
     integrations: [
         astroMermaid(),
         starlight({
@@ -13,7 +18,7 @@ export default defineConfig({
                     tag: "meta",
                     attrs: {
                         property: "og:image",
-                        content: "https://zircote.github.io/rust-template/og-image.svg",
+                        content: "https://zircote.com/rust-template/og-image.svg",
                     },
                 },
                 {
@@ -32,7 +37,7 @@ export default defineConfig({
                     tag: "meta",
                     attrs: {
                         name: "twitter:image",
-                        content: "https://zircote.github.io/rust-template/og-image.svg",
+                        content: "https://zircote.com/rust-template/og-image.svg",
                     },
                 },
             ],


### PR DESCRIPTION
## Problem

The published docs at https://zircote.com/rust-template/ render as **unstyled HTML** — all CSS, JS, and images 404.

**Root cause:** `astro.config.mjs` set `site: "https://zircote.github.io/rust-template"` with **no `base`**. Astro then emitted asset URLs from the root (`/_astro/...`), but the site is served under `/rust-template/`, so `zircote.com/_astro/...` → **404**.

```
# before (deployed HTML)
href="/_astro/print.DNXP8c50.css"   → https://zircote.com/_astro/... → 404
```

## Fix

Split `site` (origin) from `base` (project path), and stop overriding `--site` in the workflow (a path segment in `--site` double-counts against `base`):

| | before | after |
|---|---|---|
| `site` | `https://zircote.github.io/rust-template` | `https://zircote.com` |
| `base` | *(unset)* | `/rust-template` |
| workflow build | `astro build --site …/rust-template` | `astro build` (config-driven) |

Also points `og:image`/`twitter:image` at the real domain.

## Verification

```
$ npx astro build   # local
href="/rust-template/_astro/print.DNXP8c50.css"   ✅ resolves under /rust-template/
```

After merge, the opt-in `docs-deploy` run (`DEPLOY_DOCS=true`, now set) republishes the styled site.