### PR TITLE
fix(docs): base-prefix internal doc links so Pages navigation works

### DIFF
--- a/site/scripts/docs-mapping.json
+++ b/site/scripts/docs-mapping.json
@@ -1,5 +1,6 @@
 {
   "outputDir": "src/content/docs",
+  "basePath": "/rust-template",
   "pages": [
     {
       "source": "docs/template/GETTING-STARTED.md",

--- a/site/scripts/generate-docs-pages.mjs
+++ b/site/scripts/generate-docs-pages.mjs
@@ -13,11 +13,14 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, "..", "..");
 const siteRoot = resolve(__dirname, "..");
 
-function buildLinkMap(mappingPages) {
+function buildLinkMap(mappingPages, basePath = "") {
     const linkMap = {};
     for (const page of mappingPages) {
         const filename = page.source.split("/").pop();
-        const url = "/" + page.output.replace(/\.mdx$/, "/");
+        // Internal links must include the Pages base path (e.g. /rust-template),
+        // otherwise they resolve to the domain root and 404. `basePath` mirrors
+        // `base` in astro.config.mjs.
+        const url = basePath + "/" + page.output.replace(/\.mdx$/, "/");
         linkMap[filename] = url;
     }
     linkMap["CONTRIBUTING.md"] =
@@ -70,7 +73,7 @@ function buildFrontmatter(page, extractedTitle) {
  */
 export function generateDocsPages(outputBase) {
     const mapping = JSON.parse(readFileSync(join(__dirname, "docs-mapping.json"), "utf-8"));
-    const linkMap = buildLinkMap(mapping.pages);
+    const linkMap = buildLinkMap(mapping.pages, mapping.basePath ?? "");
     const outDir = outputBase || join(siteRoot, mapping.outputDir);
     const generated = [];
     const skipped = [];

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -7,7 +7,7 @@ hero:
   tagline: A comprehensive GitHub template for production-ready Rust crates
   actions:
     - text: Get Started
-      link: /getting-started/getting-started/
+      link: /rust-template/getting-started/getting-started/
       icon: right-arrow
       variant: primary
     - text: View on GitHub


### PR DESCRIPTION
## Problem

Clicking **Get Started** (and other in-page links) navigated to `https://zircote.com/getting-started/getting-started/` → **404**. The correct target is `https://zircote.com/rust-template/getting-started/getting-started/` — the links were missing the `/rust-template` Pages base.

## Root cause (two sources)

1. **Generated cross-links** — `generate-docs-pages.mjs` `buildLinkMap()` rewrote doc-to-doc links to `"/" + output` (e.g. `/getting-started/configuration/`), with no base. Starlight base-prefixes its *own* nav (sidebar/pagination) but not link targets baked into Markdown.
2. **Hand-authored hero link** — `index.mdx` (splash page, not generated) had `link: /getting-started/getting-started/`.

## Fix

- Add `basePath` to `docs-mapping.json` (mirrors `base` in `astro.config.mjs`); `buildLinkMap` prepends it → generated links emit `/rust-template/<page>/`.
- Base-prefix the hero action link in `index.mdx`.

CI runs `npm run generate` before building, so the generator + mapping + hero are the source of truth — the generated `.mdx` are **not** committed here (committing the full regeneration would bundle ~1.5k lines of unrelated, pre-existing content drift between `docs/**` source and the stale committed pages).

## Verification

```
npm run generate → 0 base-less internal links remain across all generated docs
npx astro build  → dist renders:
  hero:       href="/rust-template/getting-started/getting-started/"
  cross-link: href="/rust-template/getting-started/configuration/"
```

> Note: the committed generated `.mdx` are independently stale vs `docs/**` source (~1.5k lines); the weekly docs-freshness workflow already tracks that. Out of scope here.