### PR TITLE
fix(ci): decouple GitHub Release from the external-publish gate

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -82,18 +82,20 @@ NOTES
 
 ## Phase 0 — Preflight
 
-0. **Publication gate** — this project ships from rust-template, where
-   all publication channels are disabled by `publish = false` in
-   Cargo.toml (the workflows read it via `cargo metadata`; release
-   creation, crates.io publishing, the container chain, and Homebrew
-   updates all skip while it is set). Check it first:
+0. **External-publication gate** — `publish = false` in Cargo.toml gates the
+   EXTERNAL channels only: crates.io, the container image, and Homebrew. It
+   does **not** gate the GitHub Release — a pushed tag always produces an
+   attested GitHub Release (binaries + SBOM + source snapshot). Resolve which
+   channels are armed and report it; do not stop:
    ```bash
    cargo metadata --no-deps --format-version 1 \
-     | jq -r 'if .packages[0].publish == [] then "DISABLED" else "ENABLED" end'
+     | jq -r 'if .packages[0].publish == [] then "EXTERNAL PUBLISH DISABLED (GitHub Release only)" else "ALL CHANNELS ARMED" end'
    ```
-   If DISABLED, stop and tell the user: releasing requires deleting the
-   `publish = false` line (and its comment block) from Cargo.toml. For
-   the template repository itself this is by design — do not release.
+   - If DISABLED: proceed — this release will create the attested GitHub
+     Release and **skip** crates.io / container / Homebrew. State this plainly
+     in the first progress message so the operator knows what will ship.
+   - If ARMED: the full chain runs, including the irreversible crates.io
+     publish — confirm that is intended before tagging (see Phase 4 caveats).
 1. `git checkout main && git pull`; working tree must be clean of tracked
    changes (untracked noise is fine).
 2. Resolve the target version from the argument:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -451,9 +451,12 @@ jobs:
 
   release:
     name: Create Release
-    if: >-
-      startsWith(github.ref, 'refs/tags/')
-      && needs.meta.outputs.publishable == 'true'
+    # A GitHub Release is a tag primitive — it does NOT depend on external
+    # publication. Any pushed tag that passes the fail-closed `verify` gate
+    # gets an attested GitHub Release. `publishable` (Cargo.toml `publish`)
+    # gates only the EXTERNAL channels: crates.io (publish.yml), the container
+    # image (pipeline.yml), and Homebrew (package-homebrew.yml).
+    if: startsWith(github.ref, 'refs/tags/')
     needs: [meta, verify, audit, test]
     runs-on: ubuntu-latest
     environment: copilot

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,14 @@ documentation = "https://docs.rs/rust_template"
 readme = "README.md"
 keywords = ["template", "rust", "example"]
 categories = ["development-tools"]
-# Template repos publish nothing. This single switch disables crates.io
-# publishing, GitHub Release creation, and Homebrew tap updates (the
+# Gates EXTERNAL publication only. This single switch disables crates.io
+# publishing, the container image push, and Homebrew tap updates (the
 # workflows read it via `cargo metadata` at runtime) — and cargo itself
-# refuses `cargo publish` while it is set. DELETE this line in a real
-# project to arm the release/publish/homebrew channels.
+# refuses `cargo publish` while it is set. It does NOT gate GitHub Releases:
+# a pushed tag always produces an attested GitHub Release (binaries + SBOM +
+# source snapshot), because a release is a tag primitive, not a publish.
+# DELETE this line in a real project to arm the crates.io / container /
+# Homebrew channels.
 publish = false
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ This template includes production-ready workflows:
 
 ### Release and Deployment
 
-> **Template state: publication disabled.** `publish = false` in Cargo.toml gates GitHub Release creation, crates.io publishing, and Homebrew updates (workflows read it via `cargo metadata`); the build → attest → verify chain still runs as CI validation. Delete that line in your project to arm all three channels.
+> **Template state: external publication disabled.** `publish = false` in Cargo.toml gates the three *external* channels — crates.io publishing, the container image push, and Homebrew updates (workflows read it via `cargo metadata`). It does **not** gate GitHub Releases: a pushed tag always produces an attested GitHub Release (binaries + SBOM + source snapshot), because a release is a tag primitive, not an external publish. Delete that line in your project to arm the three external channels.
 
 - **Release** (`.github/workflows/release.yml`) - Attested GitHub releases with multi-platform binaries
   - Builds for: Linux (`x86_64`, ARM64), macOS (`x86_64`, ARM64), Windows (`x86_64`)

--- a/docs/security/ATTESTED-DELIVERY.md
+++ b/docs/security/ATTESTED-DELIVERY.md
@@ -79,23 +79,34 @@ publish = false
 
 Every release-side workflow resolves this at runtime via
 `cargo metadata --no-deps --locked --format-version 1`, mapping
-`.packages[0].publish == []` to `publishable = "false"`. That single boolean
-is the master switch. Deleting the `publish = false` line arms all four
-outward-facing channels at once.
+`.packages[0].publish == []` to `publishable = "false"`. That boolean gates the
+three **external** channels. Deleting the `publish = false` line arms them at
+once.
 
-**Exactly what `publish = false` disables:**
+A **GitHub Release is deliberately *not* gated by this switch** — it is a tag
+primitive, not an external publish. A pushed tag always produces an attested
+GitHub Release (binaries + SBOM + source snapshot), in both template and armed
+state, provided the fail-closed `verify` job passes.
+
+**What `publish = false` disables (external channels only):**
 
 | Channel | Mechanism in template state |
 |---|---|
 | **Container build → sign → verify** | `pipeline.yml`'s `gate` job resolves `publishable=false`; the `docker` job's `if:` requires `publishable == 'true'`, so `docker`, `docker-sign`, `docker-verify`, `gate-image`, and `attest-container-scan` are all **skipped** — the template builds no image. |
 | **crates.io publish** | `publish.yml`'s `guard` job sets `publishable=false`; the `publish` job's `if:` gates the whole job off. (cargo itself also refuses `cargo publish` while `publish = false`.) |
-| **GitHub Release creation** | `release.yml`'s `release` job requires `startsWith(github.ref, 'refs/tags/') && needs.meta.outputs.publishable == 'true'`. The build → attest → SBOM → **fail-closed verify** chain still runs as CI validation; only the final *publish of the release* is gated off. |
 | **Homebrew tap update** | `package-homebrew.yml` reads `publishable` from `Cargo.toml` *at the released tag*; every formula-push step is gated on `publishable == 'true'`. |
 
-The deploy-time *evidence chain still executes* in template state — binaries
-build, provenance and SBOM are attested, verification runs fail-closed. What
-the gate withholds is the *outward publication* of those artifacts. This lets
-the template prove the whole pipeline works without shipping anything.
+**What `publish = false` does NOT gate:**
+
+| Always runs on a tag | Mechanism |
+|---|---|
+| **GitHub Release** | `release.yml`'s `release` job is gated on `startsWith(github.ref, 'refs/tags/')` alone. It runs the full build → attest → SBOM → **fail-closed verify** chain and then creates the GitHub Release with the attested binaries, SBOM, and source snapshot — regardless of `publishable`. |
+
+The deploy-time *evidence chain always executes* — binaries build, provenance
+and SBOM are attested, verification runs fail-closed, and the GitHub Release is
+created. What `publish = false` withholds is *external distribution* (crates.io,
+container registry, Homebrew), so the template can ship attested GitHub Releases
+without claiming a crates.io name or pushing an image.
 
 ---
 
@@ -148,8 +159,9 @@ dry-run: version suffixed `-dev`, release job skipped). Flow:
    - source tarball → verify provenance + both gate verdicts, asserting the
      signer with `--signer-workflow zircote/.github/.github/workflows/reusable-attest-scan.yml`
      and the predicate-type URIs above.
-7. **`release`** (tag-gated + `publishable == 'true'`) — attaches binaries, the
-   SBOM, and `{bin}-{version}-checksums.txt` with auto-generated notes.
+7. **`release`** (tag-gated — `publishable` is **not** required) — attaches
+   binaries, the SBOM, the source snapshot, and `{bin}-{version}-checksums.txt`
+   with auto-generated notes. A pushed tag always produces this GitHub Release.
    `test` and `audit` (cargo-audit) are `needs` of this job because *a tag is
    untrusted input* — it is not guaranteed to point at a CI-green commit.
 
@@ -233,14 +245,15 @@ version that produces no diff is a no-op.
 > **Diátaxis mode: How-to.** Numbered, task-oriented, with a verification
 > command at the end.
 
-1. **Arm the channels.** Delete this one line from `Cargo.toml`:
+1. **Arm the external channels.** Delete this one line from `Cargo.toml`:
 
    ```toml
    publish = false
    ```
 
-   This single deletion arms the container chain, crates.io publish, GitHub
-   Release creation, and Homebrew — all four resolve it from `cargo metadata`.
+   This single deletion arms the container chain, crates.io publish, and
+   Homebrew — all three resolve it from `cargo metadata`. (GitHub Releases
+   already happen on every tag; this line never gated them.)
 
 2. **Set crate identity.** Edit `Cargo.toml` `name`, `version`, `description`,
    `license`, `repository`, and the `[[bin]]` name. Every release workflow is

--- a/docs/template/CI-WORKFLOWS.md
+++ b/docs/template/CI-WORKFLOWS.md
@@ -162,12 +162,14 @@ report.
 
 ## Release Workflows
 
-**Publication is disabled in the template**: `publish = false` in
-Cargo.toml gates the Create Release job, crates.io publishing, and
-Homebrew tap updates (each workflow reads it via `cargo metadata` at
-runtime). The build → attest → SBOM → fail-closed-verify chain still
-runs as CI validation. Downstream projects delete that single line to
-arm all three channels.
+**External publication is disabled in the template**: `publish = false` in
+Cargo.toml gates the three *external* channels — crates.io publishing, the
+container image push, and Homebrew tap updates (each workflow reads it via
+`cargo metadata` at runtime). It does **not** gate the GitHub Release: a
+pushed tag always produces an attested GitHub Release (binaries + SBOM +
+source snapshot), because a release is a tag primitive, not an external
+publish. Downstream projects delete that single line to arm the three
+external channels.
 
 All release workflows are **var-driven**: crate name, binary name,
 version, description, and license are resolved at runtime from

--- a/site/src/content/docs/security/attested-delivery.mdx
+++ b/site/src/content/docs/security/attested-delivery.mdx
@@ -82,23 +82,34 @@ publish = false
 
 Every release-side workflow resolves this at runtime via
 `cargo metadata --no-deps --locked --format-version 1`, mapping
-`.packages[0].publish == []` to `publishable = "false"`. That single boolean
-is the master switch. Deleting the `publish = false` line arms all four
-outward-facing channels at once.
+`.packages[0].publish == []` to `publishable = "false"`. That boolean gates the
+three **external** channels. Deleting the `publish = false` line arms them at
+once.
 
-**Exactly what `publish = false` disables:**
+A **GitHub Release is deliberately *not* gated by this switch** — it is a tag
+primitive, not an external publish. A pushed tag always produces an attested
+GitHub Release (binaries + SBOM + source snapshot), in both template and armed
+state, provided the fail-closed `verify` job passes.
+
+**What `publish = false` disables (external channels only):**
 
 | Channel | Mechanism in template state |
 |---|---|
 | **Container build → sign → verify** | `pipeline.yml`'s `gate` job resolves `publishable=false`; the `docker` job's `if:` requires `publishable == 'true'`, so `docker`, `docker-sign`, `docker-verify`, `gate-image`, and `attest-container-scan` are all **skipped** — the template builds no image. |
 | **crates.io publish** | `publish.yml`'s `guard` job sets `publishable=false`; the `publish` job's `if:` gates the whole job off. (cargo itself also refuses `cargo publish` while `publish = false`.) |
-| **GitHub Release creation** | `release.yml`'s `release` job requires `startsWith(github.ref, 'refs/tags/') && needs.meta.outputs.publishable == 'true'`. The build → attest → SBOM → **fail-closed verify** chain still runs as CI validation; only the final *publish of the release* is gated off. |
 | **Homebrew tap update** | `package-homebrew.yml` reads `publishable` from `Cargo.toml` *at the released tag*; every formula-push step is gated on `publishable == 'true'`. |
 
-The deploy-time *evidence chain still executes* in template state — binaries
-build, provenance and SBOM are attested, verification runs fail-closed. What
-the gate withholds is the *outward publication* of those artifacts. This lets
-the template prove the whole pipeline works without shipping anything.
+**What `publish = false` does NOT gate:**
+
+| Always runs on a tag | Mechanism |
+|---|---|
+| **GitHub Release** | `release.yml`'s `release` job is gated on `startsWith(github.ref, 'refs/tags/')` alone. It runs the full build → attest → SBOM → **fail-closed verify** chain and then creates the GitHub Release with the attested binaries, SBOM, and source snapshot — regardless of `publishable`. |
+
+The deploy-time *evidence chain always executes* — binaries build, provenance
+and SBOM are attested, verification runs fail-closed, and the GitHub Release is
+created. What `publish = false` withholds is *external distribution* (crates.io,
+container registry, Homebrew), so the template can ship attested GitHub Releases
+without claiming a crates.io name or pushing an image.
 
 ---
 
@@ -151,8 +162,9 @@ dry-run: version suffixed `-dev`, release job skipped). Flow:
    - source tarball → verify provenance + both gate verdicts, asserting the
      signer with `--signer-workflow zircote/.github/.github/workflows/reusable-attest-scan.yml`
      and the predicate-type URIs above.
-7. **`release`** (tag-gated + `publishable == 'true'`) — attaches binaries, the
-   SBOM, and `{bin}-{version}-checksums.txt` with auto-generated notes.
+7. **`release`** (tag-gated — `publishable` is **not** required) — attaches
+   binaries, the SBOM, the source snapshot, and `{bin}-{version}-checksums.txt`
+   with auto-generated notes. A pushed tag always produces this GitHub Release.
    `test` and `audit` (cargo-audit) are `needs` of this job because *a tag is
    untrusted input* — it is not guaranteed to point at a CI-green commit.
 
@@ -236,14 +248,15 @@ version that produces no diff is a no-op.
 > **Diátaxis mode: How-to.** Numbered, task-oriented, with a verification
 > command at the end.
 
-1. **Arm the channels.** Delete this one line from `Cargo.toml`:
+1. **Arm the external channels.** Delete this one line from `Cargo.toml`:
 
    ```toml
    publish = false
    ```
 
-   This single deletion arms the container chain, crates.io publish, GitHub
-   Release creation, and Homebrew — all four resolve it from `cargo metadata`.
+   This single deletion arms the container chain, crates.io publish, and
+   Homebrew — all three resolve it from `cargo metadata`. (GitHub Releases
+   already happen on every tag; this line never gated them.)
 
 2. **Set crate identity.** Edit `Cargo.toml` `name`, `version`, `description`,
    `license`, `repository`, and the `[[bin]]` name. Every release workflow is

--- a/site/src/content/docs/workflows/ci-workflows.mdx
+++ b/site/src/content/docs/workflows/ci-workflows.mdx
@@ -163,12 +163,14 @@ report.
 
 ## Release Workflows
 
-**Publication is disabled in the template**: `publish = false` in
-Cargo.toml gates the Create Release job, crates.io publishing, and
-Homebrew tap updates (each workflow reads it via `cargo metadata` at
-runtime). The build → attest → SBOM → fail-closed-verify chain still
-runs as CI validation. Downstream projects delete that single line to
-arm all three channels.
+**External publication is disabled in the template**: `publish = false` in
+Cargo.toml gates the three *external* channels — crates.io publishing, the
+container image push, and Homebrew tap updates (each workflow reads it via
+`cargo metadata` at runtime). It does **not** gate the GitHub Release: a
+pushed tag always produces an attested GitHub Release (binaries + SBOM +
+source snapshot), because a release is a tag primitive, not an external
+publish. Downstream projects delete that single line to arm the three
+external channels.
 
 All release workflows are **var-driven**: crate name, binary name,
 version, description, and license are resolved at runtime from


### PR DESCRIPTION
## Problem

A GitHub Release is a **tag primitive** — it should not depend on external publication. But `release.yml`'s `release` (Create Release) job was gated on:

```yaml
if: startsWith(github.ref, 'refs/tags/') && needs.meta.outputs.publishable == 'true'
```

So `publish = false` (the template's external-publish switch) **also suppressed the GitHub Release** — coupling a Git/GitHub concept to crates.io. A tag couldn't ship attested binaries without also arming crates.io/container/Homebrew.

## Fix

Drop the `publishable` condition from that job:

```yaml
if: startsWith(github.ref, 'refs/tags/')
```

Now **any pushed tag that passes the fail-closed `verify` gate produces an attested GitHub Release** (binaries + SBOM + source snapshot). `publishable` continues to gate **only** the external channels:
- crates.io → `publish.yml` (unchanged)
- container image → `pipeline.yml` (unchanged)
- Homebrew → `package-homebrew.yml` (unchanged)

## Source check (`zircote/.github`)

Per the request, I checked the central repo. **No change needed** — its `release.yml` and `reusable-release.yml` already treat the GitHub Release as independent of publishing (0 `publishable` references, no release-vs-publish coupling). The bug was rust-template's inline `release.yml` only.

## Consistency updates
`Cargo.toml` comment, `README.md` template-state note, release skill **Phase 0** (no longer hard-stops; reports which channels are armed), and the **Attested Delivery** + **CI-Workflows** docs (2 pages regenerated).

## Verification
```
release.yml          → YAML valid, actionlint clean
npm run check:freshness → exit 0
npx astro build         → exit 0
dist link audit         → 0 base-less internal hrefs
```