### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-17
+
+### Security
+
+- **deps**: Force `esbuild` >= 0.28.1 in the docs site (GHSA-gv7w-rqvm-qjhr RCE via `NPM_CONFIG_REGISTRY`, GHSA-g7r4-m6w7-qqqr Windows dev-server path traversal)
+- **docker**: Pin Dockerfile base images by digest (OpenSSF Scorecard Pinned-Dependencies, Trivy DS-0001) and add a `docker` Dependabot ecosystem to keep them fresh
+- **ci**: Harden GitHub Actions token permissions to least privilege across all workflows (OpenSSF Scorecard Token-Permissions)
+- **ci**: Scope the Trivy supply-chain scan away from the dev-only docs site, clearing license-classification noise from the code-scanning hub
+
 ### Added
 
+- **fuzz**: Add a minimal cargo-fuzz harness targeting the public `process()` parser
+- **docs**: Add an end-to-end "Attested Delivery" guide — which `zircote/.github` reusables run, the `publish` gate, the build → sign → verify chain, and a downstream adoption runbook
 - **docs-site**: Add Astro Starlight documentation site at `site/`
   - 73 browsable, searchable pages deployed to GitHub Pages
   - Auto-generated content from `docs/` markdown, `.github/workflows/*.yml`, and `CLAUDE.md` reference sections
@@ -34,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **ci**: Decouple the GitHub Release from the external-publish gate — any pushed tag now produces an attested GitHub Release (binaries + SBOM + source snapshot); `publish = false` gates only crates.io, the container image, and Homebrew
+- **release**: Align the `/release` skill with the current attested workflows (source-snapshot and gate-attestation jobs; 8 release assets)
 - **workflows**: Replace rustdoc+mdBook docs-deploy workflow with Astro Starlight site deployment
   - Builds Node.js site alongside rustdoc, embeds API docs at `/api/`
   - Triggers on `docs/**`, `site/**`, `CLAUDE.md`, and `Cargo.toml` changes
@@ -58,6 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **docs**: Fix the GitHub Pages base path so the published site renders styled (assets were 404ing) and base-prefix internal navigation links
+- **docs**: Align workflow-reference coverage with the actual workflows (remove 6 stale reference pages) and regenerate all pages so committed content matches the generators
 - Rename copilot-setup-steps job ID
 - Add cargo deny check and rustls constraints to jumpstart prompts
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rust_template"
-version = "0.1.1"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_template"
-version = "0.1.1"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.92"
 description = "A Rust template crate with modern tooling and best practices"


### PR DESCRIPTION
## Release v0.3.0 (minor)

Version-prep PR. Merge → tag `v0.3.0` → `release.yml` produces the **attested GitHub Release** (binaries + SBOM + source snapshot). crates.io / container / Homebrew stay **skipped** (`publish = false`).

### Version reconciliation
`Cargo.toml` was stale at **0.1.1** while **v0.2.0 was already tagged + released** (2026-02-07). The next minor above the latest release is **0.3.0**, which also re-aligns `Cargo.toml` with the release history. (Bumping to 0.2.0 would have collided with the existing tag/release.)

### Changes
- `Cargo.toml` `version = "0.3.0"`; `Cargo.lock` refreshed via `cargo check`.
- `CHANGELOG.md`: new `## [0.3.0] - 2026-06-17` capturing this cycle — GitHub-Release/publish **decoupling**, security hardening (esbuild, Docker digest pins, token permissions, Trivy scope), Astro docs site + **Attested Delivery** guide, cargo-fuzz harness, Pages base-path/nav fixes.

### Validation
```
cargo fmt --check → exit 0
cargo check       → exit 0 (Cargo.lock = 0.3.0)
```
The release workflow runs the full test + cargo-audit + 5-platform build + attest + fail-closed-verify gauntlet on the tag.