### PR TITLE
feat(errors): dual-consumer RFC 9457 problem+json error output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,33 @@ just audit            # Advisory database check
 - **Crate error type**: `Error` enum derived with `thiserror::Error`.
 - **Result alias**: `pub type Result<T> = std::result::Result<T, Error>`.
 - **Propagation**: use `?` operator. Never `unwrap()`, `expect()`, or `panic!()` in library code.
-- **Binary**: `main()` returns `ExitCode`; delegates to `run() -> Result`. Match on `Ok`/`Err` in `main()` and print errors to stderr.
+- **Binary**: `main()` returns `ExitCode`; delegates to `run() -> Result`. On `Err`, the binary renders the error to stderr in the format selected by `--format` / TTY (below).
+
+#### Dual-Consumer Error Output (RFC 9457)
+
+The crate emits errors for two consumers from one `Error` value: the human (the `thiserror` `Display`, unchanged) and the LLM agent (a serializable `application/problem+json` envelope). The envelope type is `ProblemDetails` in `crates/problem.rs`, re-exported from the crate root alongside `Applicability`, `CodeAction`, `SuggestedFix`, and `OutputFormat`. Map any error with `Error::to_problem()`; render for a format with `Error::render(OutputFormat)`.
+
+**Envelope members** (`ProblemDetails`):
+
+| Field | RFC 9457 role | Notes |
+|---|---|---|
+| `type` | standard | Stable, version-embedded URI (`.../v1`). |
+| `title` | standard | Short summary, stable per `type`. |
+| `status` | standard | Numeric status class. |
+| `detail` | standard | This-occurrence text; equals the `Display` string. |
+| `instance` | standard | `urn:` occurrence reference. |
+| `retry_after` | agent extension | Delta-seconds, or `null` (serialized) on non-transient errors. |
+| `suggested_fix` | agent extension | `{ description, applicability }`, or `null`. |
+| `code_actions` | agent extension | Array of LSP-`CodeAction`-shaped `{ title, kind, applicability }`. |
+| `exit_code` | optional extension | Process exit code; omitted from JSON when absent. |
+
+**Applicability markers** (on every `suggested_fix` and `code_action`): `machine_applicable` (auto-apply), `maybe_incorrect` (escalate to human), `has_placeholders` (fill slots first), `unspecified` (default; treat as `maybe_incorrect`).
+
+**Type URIs** (one per variant, distinct, versioned): `InvalidInput` → `https://zircote.com/errors/invalid-input/v1`; `OperationFailed` → `https://zircote.com/errors/operation-failed/v1`. A breaking change ships a new `/v2` URI rather than redefining `/v1`.
+
+**Format selection** (`OutputFormat::select(explicit, is_terminal)`): JSON when `--format=json` or (no flag and stderr is not a TTY); pretty otherwise. Pretty output is byte-identical to the historical `Error: {e}` line.
+
+For the rationale, see the **Dual-Consumer Error Output** explanation doc (`docs/explanation/error-architecture.md`).
 
 ### Ownership and Borrowing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ The crate emits errors for two consumers from one `Error` value: the human (the 
 
 **Applicability markers** (on every `suggested_fix` and `code_action`): `machine_applicable` (auto-apply), `maybe_incorrect` (escalate to human), `has_placeholders` (fill slots first), `unspecified` (default; treat as `maybe_incorrect`).
 
-**Type URIs** (one per variant, distinct, versioned): `InvalidInput` → `https://zircote.com/errors/invalid-input/v1`; `OperationFailed` → `https://zircote.com/errors/operation-failed/v1`. A breaking change ships a new `/v2` URI rather than redefining `/v1`.
+**Type URIs** (one per variant, distinct, versioned): `InvalidInput` → `https://zircote.com/rust-template/errors/invalid-input/v1`; `OperationFailed` → `https://zircote.com/rust-template/errors/operation-failed/v1`. A breaking change ships a new version rather than redefining the existing one. The base is a single configurable constant, `ERROR_TYPE_BASE_URI` (derived URI = `{base}/{slug}/{version}`); adopters point it at their own docs host. Each URI is dereferenceable — it resolves to a per-type reference page under `docs/reference/errors/` (the canonical source). The `instance` URN namespace tracks `CARGO_PKG_NAME`.
 
 **Format selection** (`OutputFormat::select(explicit, is_terminal)`): JSON when `--format=json` or (no flag and stderr is not a TTY); pretty otherwise. Pretty output is byte-identical to the historical `Error: {e}` line.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,8 @@ version = "0.3.0"
 dependencies = [
  "criterion",
  "proptest",
+ "serde",
+ "serde_json",
  "test-case",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,12 +38,12 @@ harness = false
 # Core dependencies
 thiserror = "2.0.18"
 
+# Serialization — powers the RFC 9457 problem+json error envelope (crates/problem.rs)
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.150"
+
 # Async runtime (uncomment if needed)
 # tokio = { version = "1.0", features = ["full"] }
-
-# Serialization (uncomment if needed)
-# serde = { version = "1.0", features = ["derive"] }
-# serde_json = "1.0"
 
 # Logging (uncomment if needed)
 # tracing = "0.1"

--- a/crates/lib.rs
+++ b/crates/lib.rs
@@ -1,5 +1,9 @@
 #![doc = include_str!("../README.md")]
 
+mod problem;
+
+pub use problem::{Applicability, CodeAction, OutputFormat, ProblemDetails, SuggestedFix};
+
 use thiserror::Error;
 
 /// Error type for `rust_template` operations.

--- a/crates/lib.rs
+++ b/crates/lib.rs
@@ -2,7 +2,9 @@
 
 mod problem;
 
-pub use problem::{Applicability, CodeAction, OutputFormat, ProblemDetails, SuggestedFix};
+pub use problem::{
+    Applicability, CodeAction, ERROR_TYPE_BASE_URI, OutputFormat, ProblemDetails, SuggestedFix,
+};
 
 use thiserror::Error;
 

--- a/crates/main.rs
+++ b/crates/main.rs
@@ -2,12 +2,13 @@
 
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
+use std::io::IsTerminal;
 use std::process::ExitCode;
 
-use rust_template::{Config, add, divide};
+use rust_template::{Config, Error, OutputFormat, add, divide};
 
 /// Runs the application logic.
-fn run() -> Result<(), rust_template::Error> {
+fn run() -> Result<(), Error> {
     let config = Config::new().with_verbose(true);
 
     if config.verbose() {
@@ -23,12 +24,40 @@ fn run() -> Result<(), rust_template::Error> {
     Ok(())
 }
 
+/// Extracts the value of an explicit `--format <value>` / `--format=<value>`
+/// argument, if present. The last occurrence wins.
+fn explicit_format<I: IntoIterator<Item = String>>(args: I) -> Option<String> {
+    let mut iter = args.into_iter();
+    let mut value = None;
+    while let Some(arg) = iter.next() {
+        if let Some(rest) = arg.strip_prefix("--format=") {
+            value = Some(rest.to_owned());
+        } else if arg == "--format" {
+            value = iter.next();
+        }
+    }
+    value
+}
+
+/// Renders a failed [`Error`] in the format selected by the `--format` flag and
+/// stderr TTY state. JSON when `--format=json` or stderr is not a terminal;
+/// pretty otherwise.
+fn render_failure(error: &Error, args: Vec<String>, stderr_is_terminal: bool) -> String {
+    let format = OutputFormat::select(explicit_format(args).as_deref(), stderr_is_terminal);
+    error.render(format)
+}
+
 /// Main entry point.
 fn main() -> ExitCode {
     match run() {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
-            eprintln!("Error: {e}");
+            let rendered = render_failure(
+                &e,
+                std::env::args().collect(),
+                std::io::stderr().is_terminal(),
+            );
+            eprintln!("{rendered}");
             ExitCode::FAILURE
         },
     }
@@ -51,5 +80,59 @@ mod tests {
     fn test_main_returns_success() {
         let exit_code = main();
         assert_eq!(exit_code, ExitCode::SUCCESS);
+    }
+
+    #[test]
+    fn test_explicit_format_parses_both_spellings() {
+        let split = vec![
+            "bin".to_string(),
+            "--format".to_string(),
+            "json".to_string(),
+        ];
+        assert_eq!(explicit_format(split).as_deref(), Some("json"));
+
+        let joined = vec!["bin".to_string(), "--format=pretty".to_string()];
+        assert_eq!(explicit_format(joined).as_deref(), Some("pretty"));
+
+        let none = vec!["bin".to_string()];
+        assert_eq!(explicit_format(none), None);
+
+        // Last occurrence wins.
+        let repeated = vec![
+            "bin".to_string(),
+            "--format=json".to_string(),
+            "--format=pretty".to_string(),
+        ];
+        assert_eq!(explicit_format(repeated).as_deref(), Some("pretty"));
+    }
+
+    #[test]
+    fn test_render_failure_selects_format() {
+        let err = divide(10, 0).unwrap_err();
+
+        // Explicit JSON flag wins over a TTY.
+        let json = render_failure(
+            &err,
+            vec!["bin".to_string(), "--format=json".to_string()],
+            true,
+        );
+        assert!(json.starts_with('{'));
+        assert!(json.contains("\"type\""));
+
+        // Explicit pretty flag is byte-identical to the historical line.
+        let pretty = render_failure(
+            &err,
+            vec!["bin".to_string(), "--format=pretty".to_string()],
+            false,
+        );
+        assert_eq!(pretty, format!("Error: {err}"));
+
+        // No flag, non-TTY defaults to JSON.
+        let piped = render_failure(&err, vec!["bin".to_string()], false);
+        assert!(piped.starts_with('{'));
+
+        // No flag, TTY defaults to pretty.
+        let tty = render_failure(&err, vec!["bin".to_string()], true);
+        assert_eq!(tty, format!("Error: {err}"));
     }
 }

--- a/crates/main.rs
+++ b/crates/main.rs
@@ -33,7 +33,11 @@ fn explicit_format<I: IntoIterator<Item = String>>(args: I) -> Option<String> {
         if let Some(rest) = arg.strip_prefix("--format=") {
             value = Some(rest.to_owned());
         } else if arg == "--format" {
-            value = iter.next();
+            // A bare, valueless trailing `--format` must not erase a format
+            // chosen earlier on the line; only update when a value follows.
+            if let Some(next) = iter.next() {
+                value = Some(next);
+            }
         }
     }
     value
@@ -104,6 +108,14 @@ mod tests {
             "--format=pretty".to_string(),
         ];
         assert_eq!(explicit_format(repeated).as_deref(), Some("pretty"));
+
+        // A bare, valueless trailing `--format` must not clobber a prior value.
+        let trailing_bare = vec![
+            "bin".to_string(),
+            "--format=json".to_string(),
+            "--format".to_string(),
+        ];
+        assert_eq!(explicit_format(trailing_bare).as_deref(), Some("json"));
     }
 
     #[test]

--- a/crates/problem.rs
+++ b/crates/problem.rs
@@ -22,7 +22,7 @@ use crate::Error;
 
 /// Base URI under which this crate's problem-type documentation is published.
 ///
-/// Every [`Error`](crate::Error) `type` URI is derived as
+/// Every [`Error`](enum@crate::Error) `type` URI is derived as
 /// `{ERROR_TYPE_BASE_URI}/{slug}/{version}` (e.g.
 /// `https://zircote.com/rust-template/errors/invalid-input/v1`). Because this is
 /// a **template**, this is the single knob an adopter changes: point it at your
@@ -314,7 +314,7 @@ impl OutputFormat {
 }
 
 /// Per-variant problem-type metadata: the identity, version, status, and exit
-/// code that compose an [`Error`](crate::Error)'s envelope. Kept in one place so
+/// code that compose an [`Error`](enum@crate::Error)'s envelope. Kept in one place so
 /// extending the enum means adding a single arm in [`Error::meta`] (plus a
 /// recovery arm in [`Error::to_problem`]), not editing several parallel matches.
 struct ProblemMeta {

--- a/crates/problem.rs
+++ b/crates/problem.rs
@@ -313,6 +313,24 @@ impl OutputFormat {
     }
 }
 
+/// Per-variant problem-type metadata: the identity, version, status, and exit
+/// code that compose an [`Error`](crate::Error)'s envelope. Kept in one place so
+/// extending the enum means adding a single arm in [`Error::meta`] (plus a
+/// recovery arm in [`Error::to_problem`]), not editing several parallel matches.
+struct ProblemMeta {
+    /// Stable, URL-safe slug for the problem type.
+    slug: &'static str,
+    /// Version segment of the type URI (e.g. `"v1"`). Per-type, so one type can
+    /// advance independently of the others.
+    version: &'static str,
+    /// Short, stable title for the problem type.
+    title: &'static str,
+    /// Numeric status class.
+    status: u16,
+    /// Process exit code emitted alongside the error.
+    exit_code: u8,
+}
+
 impl Error {
     /// The stable, version-embedded problem-type URI for this error.
     ///
@@ -327,11 +345,8 @@ impl Error {
     /// The fully-qualified type URI for this variant.
     #[must_use]
     pub fn type_uri(&self) -> String {
-        format!(
-            "{ERROR_TYPE_BASE_URI}/{}/{}",
-            self.type_slug(),
-            self.type_version()
-        )
+        let meta = self.meta();
+        format!("{ERROR_TYPE_BASE_URI}/{}/{}", meta.slug, meta.version)
     }
 
     /// Stable, URL-safe slug identifying this error's problem type.
@@ -344,43 +359,26 @@ impl Error {
     /// The `'static` slug for this variant.
     #[must_use]
     pub const fn type_slug(&self) -> &'static str {
-        match self {
-            Self::InvalidInput(_) => "invalid-input",
-            Self::OperationFailed { .. } => "operation-failed",
-        }
+        self.meta().slug
     }
 
-    /// Version segment of this error's problem-type URI.
-    ///
-    /// Per-type, so one problem type can advance to `v2` without disturbing the
-    /// others. Both current variants are at `v1`.
-    const fn type_version(&self) -> &'static str {
+    /// All per-variant problem-type metadata in one place.
+    const fn meta(&self) -> ProblemMeta {
         match self {
-            Self::InvalidInput(_) | Self::OperationFailed { .. } => "v1",
-        }
-    }
-
-    /// Short, stable title for this error's problem type.
-    const fn title(&self) -> &'static str {
-        match self {
-            Self::InvalidInput(_) => "Invalid input",
-            Self::OperationFailed { .. } => "Operation failed",
-        }
-    }
-
-    /// Numeric status class for this error.
-    const fn status(&self) -> u16 {
-        match self {
-            Self::InvalidInput(_) => 400,
-            Self::OperationFailed { .. } => 500,
-        }
-    }
-
-    /// Process exit code emitted alongside this error.
-    const fn exit_code(&self) -> u8 {
-        match self {
-            Self::InvalidInput(_) => 2,
-            Self::OperationFailed { .. } => 1,
+            Self::InvalidInput(_) => ProblemMeta {
+                slug: "invalid-input",
+                version: "v1",
+                title: "Invalid input",
+                status: 400,
+                exit_code: 2,
+            },
+            Self::OperationFailed { .. } => ProblemMeta {
+                slug: "operation-failed",
+                version: "v1",
+                title: "Operation failed",
+                status: 500,
+                exit_code: 1,
+            },
         }
     }
 
@@ -436,14 +434,15 @@ impl Error {
             ),
         };
 
+        let meta = self.meta();
         ProblemDetails::new(
             self.type_uri(),
-            self.title(),
-            self.status(),
+            meta.title,
+            meta.status,
             self.to_string(),
-            format!("urn:{}:{}", env!("CARGO_PKG_NAME"), self.type_slug()),
+            format!("urn:{}:{}", env!("CARGO_PKG_NAME"), meta.slug),
         )
-        .with_exit_code(self.exit_code())
+        .with_exit_code(meta.exit_code)
         .with_suggested_fix(fix)
         .with_code_action(action)
     }
@@ -583,6 +582,8 @@ mod tests {
         // Applicability marker present on the fix and the action.
         assert!(value["suggested_fix"]["applicability"].is_string());
         assert!(value["code_actions"][0]["applicability"].is_string());
+        // Optional exit_code extension is emitted when set (here, Some(2)).
+        assert_eq!(value["exit_code"], 2);
     }
 
     #[test]

--- a/crates/problem.rs
+++ b/crates/problem.rs
@@ -20,6 +20,21 @@ use serde::{Deserialize, Serialize};
 
 use crate::Error;
 
+/// Base URI under which this crate's problem-type documentation is published.
+///
+/// Every [`Error`](crate::Error) `type` URI is derived as
+/// `{ERROR_TYPE_BASE_URI}/{slug}/{version}` (e.g.
+/// `https://zircote.com/rust-template/errors/invalid-input/v1`). Because this is
+/// a **template**, this is the single knob an adopter changes: point it at your
+/// own documentation host and every type URI follows. The default value is the
+/// template's own docs site, where each `/{slug}/{version}` path resolves to a
+/// live problem-type reference page.
+///
+/// The occurrence `instance` URN namespace is derived separately from the crate
+/// name (`CARGO_PKG_NAME`), so renaming the crate in `Cargo.toml` needs no edit
+/// here.
+pub const ERROR_TYPE_BASE_URI: &str = "https://zircote.com/rust-template/errors";
+
 /// How confidently an agent may apply a [`SuggestedFix`] or [`CodeAction`].
 ///
 /// Modeled on the rustc diagnostic `Applicability` enum. Without this marker an
@@ -130,7 +145,7 @@ impl CodeAction {
 /// use rust_template::{Applicability, ProblemDetails, SuggestedFix};
 ///
 /// let problem = ProblemDetails::new(
-///     "https://zircote.com/errors/invalid-input/v1",
+///     "https://zircote.com/rust-template/errors/invalid-input/v1",
 ///     "Invalid input",
 ///     400,
 ///     "divisor cannot be zero",
@@ -301,18 +316,47 @@ impl OutputFormat {
 impl Error {
     /// The stable, version-embedded problem-type URI for this error.
     ///
-    /// Each variant maps to a distinct URI under `/v1`. The `v1` segment is the
-    /// versioning commitment: the meaning of a given URI never changes; a
-    /// breaking change to a problem type ships a new `/v2` URI instead.
+    /// Derived as `{base}/{slug}/{version}`, where `base` is the configurable
+    /// [`ERROR_TYPE_BASE_URI`], `slug` is [`Error::type_slug`], and `version` is
+    /// the per-type version. The version is the stability commitment: the
+    /// meaning of a given URI never changes; a breaking change to a problem type
+    /// ships a new version (e.g. `/v2`) rather than redefining the existing one.
     ///
     /// # Returns
     ///
-    /// The `'static` type URI for this variant.
+    /// The fully-qualified type URI for this variant.
     #[must_use]
-    pub const fn type_uri(&self) -> &'static str {
+    pub fn type_uri(&self) -> String {
+        format!(
+            "{ERROR_TYPE_BASE_URI}/{}/{}",
+            self.type_slug(),
+            self.type_version()
+        )
+    }
+
+    /// Stable, URL-safe slug identifying this error's problem type.
+    ///
+    /// Used both as the path segment in [`Error::type_uri`] and as the
+    /// occurrence id in the `instance` URN. Stable across releases.
+    ///
+    /// # Returns
+    ///
+    /// The `'static` slug for this variant.
+    #[must_use]
+    pub const fn type_slug(&self) -> &'static str {
         match self {
-            Self::InvalidInput(_) => "https://zircote.com/errors/invalid-input/v1",
-            Self::OperationFailed { .. } => "https://zircote.com/errors/operation-failed/v1",
+            Self::InvalidInput(_) => "invalid-input",
+            Self::OperationFailed { .. } => "operation-failed",
+        }
+    }
+
+    /// Version segment of this error's problem-type URI.
+    ///
+    /// Per-type, so one problem type can advance to `v2` without disturbing the
+    /// others. Both current variants are at `v1`.
+    const fn type_version(&self) -> &'static str {
+        match self {
+            Self::InvalidInput(_) | Self::OperationFailed { .. } => "v1",
         }
     }
 
@@ -321,14 +365,6 @@ impl Error {
         match self {
             Self::InvalidInput(_) => "Invalid input",
             Self::OperationFailed { .. } => "Operation failed",
-        }
-    }
-
-    /// Stable slug used to build the occurrence `instance` URI.
-    const fn slug(&self) -> &'static str {
-        match self {
-            Self::InvalidInput(_) => "invalid-input",
-            Self::OperationFailed { .. } => "operation-failed",
         }
     }
 
@@ -368,7 +404,7 @@ impl Error {
     /// let err = divide(10, 0).unwrap_err();
     /// let problem = err.to_problem();
     ///
-    /// assert_eq!(problem.problem_type, "https://zircote.com/errors/invalid-input/v1");
+    /// assert_eq!(problem.problem_type, "https://zircote.com/rust-template/errors/invalid-input/v1");
     /// assert_eq!(problem.detail, "invalid input: divisor cannot be zero");
     /// assert_eq!(problem.retry_after, None);
     /// assert!(problem.suggested_fix.is_some());
@@ -405,7 +441,7 @@ impl Error {
             self.title(),
             self.status(),
             self.to_string(),
-            format!("urn:rust_template:{}", self.slug()),
+            format!("urn:{}:{}", env!("CARGO_PKG_NAME"), self.type_slug()),
         )
         .with_exit_code(self.exit_code())
         .with_suggested_fix(fix)
@@ -472,7 +508,7 @@ mod tests {
 
         assert_eq!(
             problem.problem_type,
-            "https://zircote.com/errors/invalid-input/v1"
+            "https://zircote.com/rust-template/errors/invalid-input/v1"
         );
         assert!(problem.problem_type.ends_with("/v1"));
         assert_eq!(problem.title, "Invalid input");
@@ -497,7 +533,7 @@ mod tests {
 
         assert_eq!(
             problem.problem_type,
-            "https://zircote.com/errors/operation-failed/v1"
+            "https://zircote.com/rust-template/errors/operation-failed/v1"
         );
         assert!(problem.problem_type.ends_with("/v1"));
         assert_eq!(problem.title, "Operation failed");
@@ -518,6 +554,16 @@ mod tests {
         assert_ne!(invalid, failed);
         assert!(invalid.ends_with("/v1"));
         assert!(failed.ends_with("/v1"));
+    }
+
+    #[test]
+    fn type_uri_derives_from_the_configurable_base() {
+        let err = divide(1, 0).unwrap_err();
+        assert!(err.type_uri().starts_with(ERROR_TYPE_BASE_URI));
+        assert_eq!(
+            err.type_uri(),
+            format!("{ERROR_TYPE_BASE_URI}/{}/v1", err.type_slug())
+        );
     }
 
     #[test]

--- a/crates/problem.rs
+++ b/crates/problem.rs
@@ -1,0 +1,584 @@
+//! Dual-consumer error output: an RFC 9457 Problem Details envelope.
+//!
+//! A command-line tool now answers to two audiences: the human who reads the
+//! terminal, and the LLM agent that parses the bytes and decides whether to
+//! retry, escalate, or abandon. The human is served by the [`Error`] type's
+//! `Display` (unchanged). The agent is served by [`ProblemDetails`] — a
+//! serializable [RFC 9457] *Problem Details* envelope carrying the five
+//! standard members plus the three agent extensions (`retry_after`,
+//! `suggested_fix`, `code_actions`) and an [`Applicability`] marker on every
+//! suggested fix and code action.
+//!
+//! Map any [`Error`] to an envelope with [`Error::to_problem`], or render an
+//! error for a chosen [`OutputFormat`] with [`Error::render`]. The binary
+//! selects the format with [`OutputFormat::select`] (an explicit `--format`
+//! flag, falling back to stderr TTY detection).
+//!
+//! [RFC 9457]: https://www.rfc-editor.org/rfc/rfc9457
+
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+
+/// How confidently an agent may apply a [`SuggestedFix`] or [`CodeAction`].
+///
+/// Modeled on the rustc diagnostic `Applicability` enum. Without this marker an
+/// agent may apply a plausible-looking but wrong edit, so every suggested fix
+/// and code action carries one. `Unspecified` is the safe default and must be
+/// treated as `MaybeIncorrect` (escalate to a human) by consumers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum Applicability {
+    /// The agent may apply the edit and retry without human confirmation.
+    MachineApplicable,
+    /// The agent must escalate to a human before applying.
+    MaybeIncorrect,
+    /// The fix contains slots the agent must fill; lower confidence.
+    HasPlaceholders,
+    /// Applicability is unknown; consumers treat this as [`Self::MaybeIncorrect`].
+    #[default]
+    Unspecified,
+}
+
+/// A recovery suggestion tagged with an [`Applicability`] marker.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct SuggestedFix {
+    /// Free-text description of the recovery action.
+    pub description: String,
+    /// How confidently the fix may be applied.
+    pub applicability: Applicability,
+}
+
+impl SuggestedFix {
+    /// Creates a suggested fix from a description and an applicability marker.
+    ///
+    /// # Arguments
+    ///
+    /// * `description` - What the consumer should do to recover.
+    /// * `applicability` - How confidently the fix may be applied.
+    ///
+    /// # Returns
+    ///
+    /// A new [`SuggestedFix`].
+    #[must_use]
+    pub fn new(description: impl Into<String>, applicability: Applicability) -> Self {
+        Self {
+            description: description.into(),
+            applicability,
+        }
+    }
+}
+
+/// A structured edit an agent can apply directly, modeled on the LSP
+/// `CodeAction` interface.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CodeAction {
+    /// Short, human-readable title for the action.
+    pub title: String,
+    /// The kind of action (e.g. `"quickfix"`), following LSP conventions.
+    pub kind: String,
+    /// How confidently the action may be applied.
+    pub applicability: Applicability,
+}
+
+impl CodeAction {
+    /// Creates a code action from a title, kind, and applicability marker.
+    ///
+    /// # Arguments
+    ///
+    /// * `title` - Short summary of the action.
+    /// * `kind` - LSP-style action kind, e.g. `"quickfix"`.
+    /// * `applicability` - How confidently the action may be applied.
+    ///
+    /// # Returns
+    ///
+    /// A new [`CodeAction`].
+    #[must_use]
+    pub fn new(
+        title: impl Into<String>,
+        kind: impl Into<String>,
+        applicability: Applicability,
+    ) -> Self {
+        Self {
+            title: title.into(),
+            kind: kind.into(),
+            applicability,
+        }
+    }
+}
+
+/// An [RFC 9457] *Problem Details* envelope for machine consumers.
+///
+/// Serializes under the `application/problem+json` media type. It carries the
+/// five standard members (`type`, `title`, `status`, `detail`, `instance`), the
+/// three agent extensions (`retry_after`, `suggested_fix`, `code_actions`), and
+/// the optional `exit_code` extension. `retry_after` serializes even when
+/// `None` (as JSON `null`) so an agent never has to guess whether a class is
+/// transient.
+///
+/// Build one with [`ProblemDetails::new`] and the `with_*` methods, or map an
+/// existing [`Error`](enum@crate::Error) with [`Error::to_problem`].
+///
+/// [RFC 9457]: https://www.rfc-editor.org/rfc/rfc9457
+///
+/// # Examples
+///
+/// ```rust
+/// use rust_template::{Applicability, ProblemDetails, SuggestedFix};
+///
+/// let problem = ProblemDetails::new(
+///     "https://zircote.com/errors/invalid-input/v1",
+///     "Invalid input",
+///     400,
+///     "divisor cannot be zero",
+///     "urn:rust_template:invalid-input",
+/// )
+/// .with_exit_code(2)
+/// .with_suggested_fix(SuggestedFix::new(
+///     "Provide a non-zero divisor.",
+///     Applicability::MaybeIncorrect,
+/// ));
+///
+/// assert_eq!(problem.status, 400);
+/// assert_eq!(problem.retry_after, None);
+/// assert!(problem.to_json().contains("\"type\""));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ProblemDetails {
+    /// A URI reference identifying the problem type. Stable and versioned.
+    #[serde(rename = "type")]
+    pub problem_type: String,
+    /// Short, human-readable summary of the problem type. Stable per `type`.
+    pub title: String,
+    /// Numeric status mapping to a status class (see also `exit_code`).
+    pub status: u16,
+    /// Human-readable explanation specific to this occurrence.
+    pub detail: String,
+    /// URI reference identifying this specific occurrence.
+    pub instance: String,
+    /// When the operation may safely be retried (delta-seconds). Explicitly
+    /// `null` for non-transient errors so agents do not have to guess.
+    pub retry_after: Option<u64>,
+    /// A recovery suggestion, tagged with an applicability marker.
+    pub suggested_fix: Option<SuggestedFix>,
+    /// Structured edits the agent can apply directly.
+    pub code_actions: Vec<CodeAction>,
+    /// The process exit code emitted alongside the error, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<u8>,
+}
+
+impl ProblemDetails {
+    /// Creates an envelope from the five RFC 9457 standard members.
+    ///
+    /// `retry_after`, `suggested_fix`, `code_actions`, and `exit_code` start
+    /// empty; add them with the `with_*` methods.
+    ///
+    /// # Arguments
+    ///
+    /// * `problem_type` - Stable, versioned problem-type URI.
+    /// * `title` - Short summary, stable per `problem_type`.
+    /// * `status` - Numeric status class.
+    /// * `detail` - This-occurrence explanation.
+    /// * `instance` - URI identifying this occurrence.
+    ///
+    /// # Returns
+    ///
+    /// A new [`ProblemDetails`] with no extensions set.
+    #[must_use]
+    pub fn new(
+        problem_type: impl Into<String>,
+        title: impl Into<String>,
+        status: u16,
+        detail: impl Into<String>,
+        instance: impl Into<String>,
+    ) -> Self {
+        Self {
+            problem_type: problem_type.into(),
+            title: title.into(),
+            status,
+            detail: detail.into(),
+            instance: instance.into(),
+            retry_after: None,
+            suggested_fix: None,
+            code_actions: Vec::new(),
+            exit_code: None,
+        }
+    }
+
+    /// Sets `retry_after` to `seconds`, marking the error as transient.
+    #[must_use]
+    pub const fn with_retry_after(mut self, seconds: u64) -> Self {
+        self.retry_after = Some(seconds);
+        self
+    }
+
+    /// Attaches a [`SuggestedFix`].
+    #[must_use]
+    pub fn with_suggested_fix(mut self, fix: SuggestedFix) -> Self {
+        self.suggested_fix = Some(fix);
+        self
+    }
+
+    /// Appends a [`CodeAction`] to `code_actions`.
+    #[must_use]
+    pub fn with_code_action(mut self, action: CodeAction) -> Self {
+        self.code_actions.push(action);
+        self
+    }
+
+    /// Sets the `exit_code` extension.
+    #[must_use]
+    pub const fn with_exit_code(mut self, code: u8) -> Self {
+        self.exit_code = Some(code);
+        self
+    }
+
+    /// Serializes the envelope as a compact `application/problem+json` string.
+    ///
+    /// # Returns
+    ///
+    /// The compact JSON representation. Returns `"{}"` only if serialization
+    /// fails, which cannot happen for this all-owned, self-describing struct.
+    #[must_use]
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap_or_else(|_| String::from("{}"))
+    }
+
+    /// Serializes the envelope as pretty-printed `application/problem+json`.
+    ///
+    /// # Returns
+    ///
+    /// The indented JSON representation, suitable for human inspection.
+    #[must_use]
+    pub fn to_json_pretty(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap_or_else(|_| String::from("{}"))
+    }
+}
+
+/// The rendering format for an [`Error`](enum@crate::Error) reported to a consumer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum OutputFormat {
+    /// The human-readable `Display` line ("as lush as it ever was").
+    Pretty,
+    /// The RFC 9457 `application/problem+json` envelope.
+    Json,
+}
+
+impl OutputFormat {
+    /// Selects the output format for a consumer.
+    ///
+    /// JSON when `--format=json` is given explicitly, or when no format is
+    /// given and the error stream is not a terminal. Pretty when
+    /// `--format=pretty` is given, or when no format is given and the error
+    /// stream is a terminal. An unrecognized explicit value falls back to the
+    /// TTY heuristic.
+    ///
+    /// # Arguments
+    ///
+    /// * `explicit` - The value of an explicit `--format` flag, if any.
+    /// * `is_terminal` - Whether the error stream is a TTY.
+    ///
+    /// # Returns
+    ///
+    /// The selected [`OutputFormat`].
+    #[must_use]
+    pub fn select(explicit: Option<&str>, is_terminal: bool) -> Self {
+        match explicit {
+            Some("json") => Self::Json,
+            Some("pretty") => Self::Pretty,
+            _ if is_terminal => Self::Pretty,
+            _ => Self::Json,
+        }
+    }
+}
+
+impl Error {
+    /// The stable, version-embedded problem-type URI for this error.
+    ///
+    /// Each variant maps to a distinct URI under `/v1`. The `v1` segment is the
+    /// versioning commitment: the meaning of a given URI never changes; a
+    /// breaking change to a problem type ships a new `/v2` URI instead.
+    ///
+    /// # Returns
+    ///
+    /// The `'static` type URI for this variant.
+    #[must_use]
+    pub const fn type_uri(&self) -> &'static str {
+        match self {
+            Self::InvalidInput(_) => "https://zircote.com/errors/invalid-input/v1",
+            Self::OperationFailed { .. } => "https://zircote.com/errors/operation-failed/v1",
+        }
+    }
+
+    /// Short, stable title for this error's problem type.
+    const fn title(&self) -> &'static str {
+        match self {
+            Self::InvalidInput(_) => "Invalid input",
+            Self::OperationFailed { .. } => "Operation failed",
+        }
+    }
+
+    /// Stable slug used to build the occurrence `instance` URI.
+    const fn slug(&self) -> &'static str {
+        match self {
+            Self::InvalidInput(_) => "invalid-input",
+            Self::OperationFailed { .. } => "operation-failed",
+        }
+    }
+
+    /// Numeric status class for this error.
+    const fn status(&self) -> u16 {
+        match self {
+            Self::InvalidInput(_) => 400,
+            Self::OperationFailed { .. } => 500,
+        }
+    }
+
+    /// Process exit code emitted alongside this error.
+    const fn exit_code(&self) -> u8 {
+        match self {
+            Self::InvalidInput(_) => 2,
+            Self::OperationFailed { .. } => 1,
+        }
+    }
+
+    /// Maps this error to an RFC 9457 [`ProblemDetails`] envelope.
+    ///
+    /// The `detail` member is this error's `Display` string, so the human
+    /// rendering and the machine `detail` never drift. Both current variants
+    /// are non-transient, so `retry_after` is left `None` (serialized as JSON
+    /// `null`). Every envelope carries a `suggested_fix` and a `code_action`,
+    /// each with an [`Applicability`] marker.
+    ///
+    /// # Returns
+    ///
+    /// A fully-populated [`ProblemDetails`] for this error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use rust_template::{Error, divide};
+    ///
+    /// let err = divide(10, 0).unwrap_err();
+    /// let problem = err.to_problem();
+    ///
+    /// assert_eq!(problem.problem_type, "https://zircote.com/errors/invalid-input/v1");
+    /// assert_eq!(problem.detail, "invalid input: divisor cannot be zero");
+    /// assert_eq!(problem.retry_after, None);
+    /// assert!(problem.suggested_fix.is_some());
+    /// ```
+    #[must_use]
+    pub fn to_problem(&self) -> ProblemDetails {
+        let (fix, action) = match self {
+            Self::InvalidInput(_) => (
+                SuggestedFix::new(
+                    "Correct the input so it satisfies the documented constraints, then retry.",
+                    Applicability::MaybeIncorrect,
+                ),
+                CodeAction::new(
+                    "Replace the offending input with a valid value",
+                    "quickfix",
+                    Applicability::MaybeIncorrect,
+                ),
+            ),
+            Self::OperationFailed { .. } => (
+                SuggestedFix::new(
+                    "Inspect the operation's operands; the operation could not complete.",
+                    Applicability::Unspecified,
+                ),
+                CodeAction::new(
+                    "Adjust the operands so the operation can complete",
+                    "quickfix",
+                    Applicability::Unspecified,
+                ),
+            ),
+        };
+
+        ProblemDetails::new(
+            self.type_uri(),
+            self.title(),
+            self.status(),
+            self.to_string(),
+            format!("urn:rust_template:{}", self.slug()),
+        )
+        .with_exit_code(self.exit_code())
+        .with_suggested_fix(fix)
+        .with_code_action(action)
+    }
+
+    /// Renders this error for the given [`OutputFormat`].
+    ///
+    /// Pretty rendering is byte-identical to the binary's historical
+    /// `Error: {e}` line. JSON rendering is the compact RFC 9457 envelope.
+    ///
+    /// # Arguments
+    ///
+    /// * `format` - The format to render.
+    ///
+    /// # Returns
+    ///
+    /// The rendered error string (without a trailing newline).
+    #[must_use]
+    pub fn render(&self, format: OutputFormat) -> String {
+        match format {
+            OutputFormat::Pretty => format!("Error: {self}"),
+            OutputFormat::Json => self.to_problem().to_json(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{divide, process};
+
+    #[test]
+    fn applicability_serializes_snake_case() {
+        let json = serde_json::to_string(&Applicability::MachineApplicable).unwrap();
+        assert_eq!(json, "\"machine_applicable\"");
+        assert_eq!(Applicability::default(), Applicability::Unspecified);
+    }
+
+    #[test]
+    fn builder_sets_every_extension() {
+        let problem = ProblemDetails::new("t", "T", 429, "d", "urn:x")
+            .with_retry_after(180)
+            .with_suggested_fix(SuggestedFix::new("wait", Applicability::MachineApplicable))
+            .with_code_action(CodeAction::new(
+                "retry",
+                "quickfix",
+                Applicability::MachineApplicable,
+            ))
+            .with_exit_code(2);
+
+        assert_eq!(problem.retry_after, Some(180));
+        assert_eq!(problem.exit_code, Some(2));
+        assert_eq!(problem.code_actions.len(), 1);
+        assert_eq!(
+            problem.suggested_fix.unwrap().applicability,
+            Applicability::MachineApplicable
+        );
+    }
+
+    #[test]
+    fn invalid_input_maps_to_versioned_envelope() {
+        let problem = divide(1, 0).unwrap_err().to_problem();
+
+        assert_eq!(
+            problem.problem_type,
+            "https://zircote.com/errors/invalid-input/v1"
+        );
+        assert!(problem.problem_type.ends_with("/v1"));
+        assert_eq!(problem.title, "Invalid input");
+        assert_eq!(problem.status, 400);
+        assert_eq!(problem.detail, "invalid input: divisor cannot be zero");
+        assert_eq!(problem.instance, "urn:rust_template:invalid-input");
+        assert_eq!(problem.retry_after, None);
+        assert_eq!(problem.exit_code, Some(2));
+        assert_eq!(
+            problem.suggested_fix.unwrap().applicability,
+            Applicability::MaybeIncorrect
+        );
+        assert_eq!(
+            problem.code_actions[0].applicability,
+            Applicability::MaybeIncorrect
+        );
+    }
+
+    #[test]
+    fn operation_failed_maps_to_distinct_versioned_envelope() {
+        let problem = process("-5").unwrap_err().to_problem();
+
+        assert_eq!(
+            problem.problem_type,
+            "https://zircote.com/errors/operation-failed/v1"
+        );
+        assert!(problem.problem_type.ends_with("/v1"));
+        assert_eq!(problem.title, "Operation failed");
+        assert_eq!(problem.status, 500);
+        assert_eq!(problem.instance, "urn:rust_template:operation-failed");
+        assert_eq!(problem.retry_after, None);
+        assert_eq!(problem.exit_code, Some(1));
+        assert_eq!(
+            problem.code_actions[0].applicability,
+            Applicability::Unspecified
+        );
+    }
+
+    #[test]
+    fn every_variant_has_a_distinct_type_uri() {
+        let invalid = divide(1, 0).unwrap_err().type_uri();
+        let failed = process("-1").unwrap_err().type_uri();
+        assert_ne!(invalid, failed);
+        assert!(invalid.ends_with("/v1"));
+        assert!(failed.ends_with("/v1"));
+    }
+
+    #[test]
+    fn json_envelope_carries_all_required_members() {
+        let json = divide(1, 0).unwrap_err().to_problem().to_json();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        // Five RFC 9457 standard members.
+        for member in ["type", "title", "status", "detail", "instance"] {
+            assert!(value.get(member).is_some(), "missing {member}");
+        }
+        // Three agent extensions; retry_after present even when null.
+        assert!(value.get("retry_after").is_some());
+        assert!(value["retry_after"].is_null());
+        assert!(value.get("suggested_fix").is_some());
+        assert!(value.get("code_actions").is_some());
+        // Applicability marker present on the fix and the action.
+        assert!(value["suggested_fix"]["applicability"].is_string());
+        assert!(value["code_actions"][0]["applicability"].is_string());
+    }
+
+    #[test]
+    fn pretty_render_is_byte_identical_to_display_line() {
+        let err = divide(1, 0).unwrap_err();
+        assert_eq!(err.render(OutputFormat::Pretty), format!("Error: {err}"));
+    }
+
+    #[test]
+    fn json_render_matches_envelope_json() {
+        let err = divide(1, 0).unwrap_err();
+        assert_eq!(err.render(OutputFormat::Json), err.to_problem().to_json());
+    }
+
+    #[test]
+    fn format_selection_honors_flag_then_tty() {
+        assert_eq!(OutputFormat::select(Some("json"), true), OutputFormat::Json);
+        assert_eq!(
+            OutputFormat::select(Some("pretty"), false),
+            OutputFormat::Pretty
+        );
+        assert_eq!(OutputFormat::select(None, true), OutputFormat::Pretty);
+        assert_eq!(OutputFormat::select(None, false), OutputFormat::Json);
+        // Unrecognized explicit value falls back to the TTY heuristic.
+        assert_eq!(
+            OutputFormat::select(Some("xml"), true),
+            OutputFormat::Pretty
+        );
+    }
+
+    #[test]
+    fn envelope_round_trips_through_json() {
+        let problem = divide(1, 0).unwrap_err().to_problem();
+        let json = problem.to_json();
+        let back: ProblemDetails = serde_json::from_str(&json).unwrap();
+        assert_eq!(problem, back);
+    }
+
+    #[test]
+    fn pretty_json_is_indented() {
+        let pretty = divide(1, 0).unwrap_err().to_problem().to_json_pretty();
+        assert!(pretty.contains('\n'));
+        assert!(pretty.contains("  \"type\""));
+    }
+}

--- a/docs/explanation/error-architecture.md
+++ b/docs/explanation/error-architecture.md
@@ -91,17 +91,30 @@ never treated as auto-applicable.
 
 Each `Error` variant maps to a distinct, version-embedded `type` URI:
 
-| Variant           | Type URI                                         |
-|-------------------|--------------------------------------------------|
-| `InvalidInput`    | `https://zircote.com/errors/invalid-input/v1`    |
-| `OperationFailed` | `https://zircote.com/errors/operation-failed/v1` |
+| Variant           | Type URI                                                       |
+|-------------------|----------------------------------------------------------------|
+| `InvalidInput`    | `https://zircote.com/rust-template/errors/invalid-input/v1`    |
+| `OperationFailed` | `https://zircote.com/rust-template/errors/operation-failed/v1` |
 
 The policy is a **commitment**: the meaning of a given URI never changes. The
-`/v1` segment is the version. A breaking change to a problem type's semantics
-ships a new `/v2` URI rather than redefining `/v1`. Agents that key behavior off
-a `type` URI can therefore rely on it across releases. The URIs are stable and
-distinct per variant, which lets agents branch on the problem type without
-parsing prose.
+`/v1` segment is the version, carried per problem type so one type can advance to
+`/v2` without disturbing the others. A breaking change to a type's semantics
+ships a new version rather than redefining the existing one. Agents that key
+behavior off a `type` URI can therefore rely on it across releases.
+
+Each URI is **dereferenceable**: it resolves to a live problem-type reference
+page (the documentation registry lives at
+`https://zircote.com/rust-template/errors/`). Those per-type pages are the source
+of truth for a type's status, recovery action, and stability — see the
+**Errors** reference.
+
+**Configurable for adopters.** Because this is a template, the URI host is not
+hardcoded across the code. A single constant, `ERROR_TYPE_BASE_URI`, holds the
+base (`https://zircote.com/rust-template/errors` by default); every type URI is
+derived as `{base}/{slug}/{version}`. An adopter points that one constant at
+their own documentation host and all type URIs follow. The occurrence `instance`
+URN namespace is derived from the crate name (`CARGO_PKG_NAME`), so renaming the
+crate in `Cargo.toml` updates it automatically.
 
 ## The dual renderer
 
@@ -138,7 +151,7 @@ JSON (`application/problem+json`):
 
 ```json
 {
-  "type": "https://zircote.com/errors/invalid-input/v1",
+  "type": "https://zircote.com/rust-template/errors/invalid-input/v1",
   "title": "Invalid input",
   "status": 400,
   "detail": "invalid input: divisor cannot be zero",

--- a/docs/explanation/error-architecture.md
+++ b/docs/explanation/error-architecture.md
@@ -1,0 +1,180 @@
+---
+diataxis_type: explanation
+---
+# Dual-Consumer Error Output
+
+This document explains the error-output architecture that `rust_template` ships
+as a foundation for adopters: a single binary that serves **two** audiences from
+**one** error value. It covers why the architecture exists, the envelope fields,
+the applicability markers, the type-URI versioning policy, and how the dual
+renderer selects a format. For the source-level error conventions (`thiserror`,
+the `Result` alias, `?` propagation), see the **Error Handling** reference.
+
+## Why error output is a dual-consumer problem
+
+A command-line tool now answers to two distinct consumers:
+
+1. **The human** who ran the command and reads the terminal.
+2. **The LLM agent** that orchestrated the command, parses the bytes, and decides
+   whether to retry, escalate, or abandon.
+
+Most CLIs serve the first consumer well and the second poorly. That imbalance is
+not a polish problem — it is a cost, reliability, and convergence problem. A
+verbose traceback shipped into an agent's `tool_result` burns tokens (a 5 KB
+traceback is roughly 1,600 tokens; a structured envelope cuts that by about
+75 %). A transient error without a retry directive causes agents to abandon
+recoverable work. An unmarked "suggested fix" invites agents to apply
+plausible-looking but wrong edits.
+
+The architecture's response is the model from
+[RFC 9457 *Problem Details*](https://www.rfc-editor.org/rfc/rfc9457): the human
+keeps the lush `Display` line unchanged, and the agent gets a structured
+`application/problem+json` envelope carrying the standard members plus three
+agent-facing extensions. The two renderings come from one `Error` value, so they
+can never drift.
+
+## The envelope
+
+`ProblemDetails` is a serializable struct. It is hand-rolled on `serde` (no
+heavyweight diagnostic framework), keeping the dependency surface to `serde` and
+`serde_json`, both of which pass `cargo deny check`.
+
+### Standard members (RFC 9457)
+
+| Member     | Type         | Meaning                                                       |
+|------------|--------------|---------------------------------------------------------------|
+| `type`     | URI string   | Stable, versioned URI identifying the problem type.           |
+| `title`    | string       | Short human-readable summary. Stable per `type`.              |
+| `status`   | number       | Numeric status class (mirrored to the process `exit_code`).   |
+| `detail`   | string       | Explanation specific to this occurrence — the `Display` line. |
+| `instance` | URI string   | `urn:` reference identifying this specific occurrence.        |
+
+`detail` is the error's `Display` string, so the human rendering and the machine
+`detail` are the same text by construction.
+
+### Agent extensions (mandatory)
+
+| Extension       | Type           | Meaning                                                                                                          |
+|-----------------|----------------|------------------------------------------------------------------------------------------------------------------|
+| `retry_after`   | number \| null | Delta-seconds before a safe retry. **Explicitly `null`** on non-transient errors so an agent never has to guess. |
+| `suggested_fix` | object \| null | A recovery action with a description and an applicability marker.                                                 |
+| `code_actions`  | array          | Structured edits modeled on the LSP `CodeAction` interface.                                                       |
+
+`retry_after` is serialized even when absent (as JSON `null`). Both error
+variants the template ships today are non-transient, so they carry
+`retry_after: null`. An adopter modeling a rate-limit class sets it to a positive
+number with `ProblemDetails::with_retry_after`.
+
+### Optional extension
+
+| Extension   | Type   | Meaning                                            |
+|-------------|--------|----------------------------------------------------|
+| `exit_code` | number | The process exit code emitted alongside the error. |
+
+## Applicability markers
+
+Every `suggested_fix` and every `code_actions[]` entry carries an `Applicability`
+marker, modeled on the rustc diagnostic precedent. Without it, an agent cannot
+tell a safe auto-applicable edit from a guess.
+
+| Marker               | Agent contract                                                  |
+|----------------------|-----------------------------------------------------------------|
+| `machine_applicable` | Apply the edit and retry without human confirmation.            |
+| `maybe_incorrect`    | Escalate to a human before applying.                            |
+| `has_placeholders`   | The fix has slots the agent must fill; lower confidence.        |
+| `unspecified`        | Applicability unknown; consumers treat it as `maybe_incorrect`. |
+
+`unspecified` is the default and the safe floor: a missing or unknown marker is
+never treated as auto-applicable.
+
+## Type-URI versioning policy
+
+Each `Error` variant maps to a distinct, version-embedded `type` URI:
+
+| Variant           | Type URI                                         |
+|-------------------|--------------------------------------------------|
+| `InvalidInput`    | `https://zircote.com/errors/invalid-input/v1`    |
+| `OperationFailed` | `https://zircote.com/errors/operation-failed/v1` |
+
+The policy is a **commitment**: the meaning of a given URI never changes. The
+`/v1` segment is the version. A breaking change to a problem type's semantics
+ships a new `/v2` URI rather than redefining `/v1`. Agents that key behavior off
+a `type` URI can therefore rely on it across releases. The URIs are stable and
+distinct per variant, which lets agents branch on the problem type without
+parsing prose.
+
+## The dual renderer
+
+The binary ships **both** renderings and selects between them. Selection is
+`OutputFormat::select`, driven by an explicit `--format` flag first, then by
+stderr TTY detection:
+
+| `--format` | stderr is a TTY | Selected format |
+|------------|-----------------|-----------------|
+| `json`     | (ignored)       | JSON            |
+| `pretty`   | (ignored)       | Pretty          |
+| (absent)   | yes             | Pretty          |
+| (absent)   | no              | JSON            |
+
+The rationale for honoring both signals: a human at a terminal gets the lush line
+by default; the same binary, run by an agent or in a pipe (no TTY), emits the
+structured envelope without any flag. An explicit `--format` always wins, so a
+human can force JSON and an agent can force pretty when needed.
+
+The **pretty** rendering is byte-identical to the binary's historical
+`Error: {e}` line — adopting this architecture changes nothing for human users.
+The **JSON** rendering is the compact `application/problem+json` envelope.
+
+## Worked example
+
+The `InvalidInput` variant produced by `divide(10, 0)` renders two ways from the
+same value. Pretty:
+
+```text
+Error: invalid input: divisor cannot be zero
+```
+
+JSON (`application/problem+json`):
+
+```json
+{
+  "type": "https://zircote.com/errors/invalid-input/v1",
+  "title": "Invalid input",
+  "status": 400,
+  "detail": "invalid input: divisor cannot be zero",
+  "instance": "urn:rust_template:invalid-input",
+  "retry_after": null,
+  "suggested_fix": {
+    "description": "Correct the input so it satisfies the documented constraints, then retry.",
+    "applicability": "maybe_incorrect"
+  },
+  "code_actions": [
+    {
+      "title": "Replace the offending input with a valid value",
+      "kind": "quickfix",
+      "applicability": "maybe_incorrect"
+    }
+  ],
+  "exit_code": 2
+}
+```
+
+## Why this lives in the library
+
+The envelope, the mapping, and the format selector are all part of the library
+surface, not buried in the binary. An adopter building a different binary — or a
+service, or a second CLI — reuses `ProblemDetails`, `Error::to_problem`, and
+`OutputFormat` directly. The binary in `crates/main.rs` is just the first
+consumer of a reusable contract. The cost is a slightly larger public API; the
+benefit is that every project built from the template inherits a machine-readable
+error contract for free, rather than re-implementing one per binary.
+
+## Related reading
+
+- The **Error Handling** reference — the field tables and source conventions in
+  lookup form.
+- **Architecture & Design** — the broader "why" behind the template's layout, CI,
+  and lint philosophy.
+- [RFC 9457 — Problem Details for HTTP APIs](https://www.rfc-editor.org/rfc/rfc9457)
+- [LSP `CodeAction`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeAction)
+  — the shape `code_actions[]` follows.

--- a/docs/reference/errors/README.md
+++ b/docs/reference/errors/README.md
@@ -1,0 +1,28 @@
+---
+diataxis_type: reference
+---
+# Error Type Registry
+
+The canonical registry of problem types this crate emits as RFC 9457
+`application/problem+json` envelopes. Each `type` URI below is dereferenceable —
+it resolves to its own reference page, which is the source of truth for that
+type's status, recovery action, and stability.
+
+| Problem type | Status | Exit code | Retryable |
+|---|---|---|---|
+| [Invalid input](https://zircote.com/rust-template/errors/invalid-input/v1) | 400 | 2 | No |
+| [Operation failed](https://zircote.com/rust-template/errors/operation-failed/v1) | 500 | 1 | No |
+
+For the envelope structure, applicability markers, and renderer selection, see
+the **Dual-Consumer Error Output** explanation.
+
+## Customizing the base URI
+
+This is a template, so the URI host is a single configurable knob, not a
+hardcoded string. The constant `ERROR_TYPE_BASE_URI` in `crates/problem.rs`
+holds the base (`https://zircote.com/rust-template/errors` by default); every
+type URI is derived as `{base}/{slug}/{version}`. An adopter sets that one
+constant to their own documentation host and all type URIs follow. The
+occurrence `instance` URN namespace is derived from the crate name
+(`CARGO_PKG_NAME`), so renaming the crate in `Cargo.toml` updates it
+automatically — no edit here.

--- a/docs/reference/errors/invalid-input.md
+++ b/docs/reference/errors/invalid-input.md
@@ -1,0 +1,66 @@
+---
+diataxis_type: reference
+---
+# Invalid input
+
+`InvalidInput` — a value supplied to an operation did not satisfy a documented
+constraint, so the operation never ran.
+
+## Identity
+
+| Field      | Value                                                          |
+|------------|----------------------------------------------------------------|
+| Type URI   | `https://zircote.com/rust-template/errors/invalid-input/v1`    |
+| Title      | `Invalid input`                                                |
+| Status     | `400`                                                          |
+| Exit code  | `2`                                                            |
+| Retryable  | No — `retry_after` is `null` (non-transient).                  |
+
+## When it occurs
+
+Returned when a value fails validation *before* an operation runs — for example
+`divide(_, 0)` (the divisor cannot be zero). The `detail` member carries the
+occurrence-specific `Display` string, such as
+`invalid input: divisor cannot be zero`.
+
+## Recovery
+
+| Field             | Value                                                                   | Applicability       |
+|-------------------|-------------------------------------------------------------------------|---------------------|
+| `suggested_fix`   | Correct the input so it satisfies the documented constraints, then retry. | `maybe_incorrect`   |
+| `code_actions[0]` | Replace the offending input with a valid value (`quickfix`).            | `maybe_incorrect`   |
+
+The applicability is `maybe_incorrect`, not `machine_applicable`: the correct
+value is domain-specific, so a consumer must escalate to a human rather than
+substitute a value automatically.
+
+## Example envelope
+
+```json
+{
+  "type": "https://zircote.com/rust-template/errors/invalid-input/v1",
+  "title": "Invalid input",
+  "status": 400,
+  "detail": "invalid input: divisor cannot be zero",
+  "instance": "urn:rust_template:invalid-input",
+  "retry_after": null,
+  "suggested_fix": {
+    "description": "Correct the input so it satisfies the documented constraints, then retry.",
+    "applicability": "maybe_incorrect"
+  },
+  "code_actions": [
+    {
+      "title": "Replace the offending input with a valid value",
+      "kind": "quickfix",
+      "applicability": "maybe_incorrect"
+    }
+  ],
+  "exit_code": 2
+}
+```
+
+## Stability
+
+This is the `v1` definition. Its meaning is stable across releases; a breaking
+change to the type's semantics ships a new version (`/v2`) rather than redefining
+`v1`.

--- a/docs/reference/errors/operation-failed.md
+++ b/docs/reference/errors/operation-failed.md
@@ -1,0 +1,67 @@
+---
+diataxis_type: reference
+---
+# Operation failed
+
+`OperationFailed` — a named operation could not complete. The inputs may have
+been individually valid, but the operation itself failed.
+
+## Identity
+
+| Field      | Value                                                             |
+|------------|-------------------------------------------------------------------|
+| Type URI   | `https://zircote.com/rust-template/errors/operation-failed/v1`    |
+| Title      | `Operation failed`                                                |
+| Status     | `500`                                                             |
+| Exit code  | `1`                                                               |
+| Retryable  | No — `retry_after` is `null` (non-transient).                     |
+
+## When it occurs
+
+Returned when an operation runs but cannot produce a result — for example
+`process("-7")` (a parsed value that is out of the operation's accepted range).
+The structured `OperationFailed` variant names the failing operation and its
+cause; the `detail` member carries the `Display` string, such as
+`operation 'process' failed: value -7 is negative`.
+
+## Recovery
+
+| Field             | Value                                                              | Applicability   |
+|-------------------|--------------------------------------------------------------------|-----------------|
+| `suggested_fix`   | Inspect the operation's operands; the operation could not complete. | `unspecified`   |
+| `code_actions[0]` | Adjust the operands so the operation can complete (`quickfix`).    | `unspecified`   |
+
+The applicability is `unspecified` — the safe floor. A consumer treats it as
+`maybe_incorrect` and escalates to a human; the cause is too general to prescribe
+a machine-applicable edit.
+
+## Example envelope
+
+```json
+{
+  "type": "https://zircote.com/rust-template/errors/operation-failed/v1",
+  "title": "Operation failed",
+  "status": 500,
+  "detail": "operation 'process' failed: value -7 is negative",
+  "instance": "urn:rust_template:operation-failed",
+  "retry_after": null,
+  "suggested_fix": {
+    "description": "Inspect the operation's operands; the operation could not complete.",
+    "applicability": "unspecified"
+  },
+  "code_actions": [
+    {
+      "title": "Adjust the operands so the operation can complete",
+      "kind": "quickfix",
+      "applicability": "unspecified"
+    }
+  ],
+  "exit_code": 1
+}
+```
+
+## Stability
+
+This is the `v1` definition. Its meaning is stable across releases; a breaking
+change to the type's semantics ships a new version (`/v2`) rather than redefining
+`v1`.

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -148,6 +148,10 @@ export default defineConfig({
                             label: "Architecture & Design",
                             slug: "explanation/architecture",
                         },
+                        {
+                            label: "Error Output (Dual-Consumer)",
+                            slug: "explanation/error-architecture",
+                        },
                     ],
                 },
                 {

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -155,6 +155,23 @@ export default defineConfig({
                     ],
                 },
                 {
+                    label: "Error Reference",
+                    items: [
+                        {
+                            label: "Error Type Registry",
+                            slug: "errors",
+                        },
+                        {
+                            label: "invalid-input/v1",
+                            slug: "errors/invalid-input/v1",
+                        },
+                        {
+                            label: "operation-failed/v1",
+                            slug: "errors/operation-failed/v1",
+                        },
+                    ],
+                },
+                {
                     label: "CI/CD & Workflows",
                     items: [
                         {

--- a/site/scripts/docs-mapping.json
+++ b/site/scripts/docs-mapping.json
@@ -239,6 +239,27 @@
       "title": "Dual-Consumer Error Output",
       "description": "Why and how the crate emits errors for both humans and LLM agents via an RFC 9457 problem+json envelope with applicability markers and a dual renderer.",
       "sidebarLabel": "Error Output (Dual-Consumer)"
+    },
+    {
+      "source": "docs/reference/errors/README.md",
+      "output": "errors.mdx",
+      "title": "Error Type Registry",
+      "description": "Canonical registry of the RFC 9457 problem types this crate emits, with dereferenceable type URIs.",
+      "sidebarLabel": "Error Type Registry"
+    },
+    {
+      "source": "docs/reference/errors/invalid-input.md",
+      "output": "errors/invalid-input/v1.mdx",
+      "title": "Invalid input",
+      "description": "Reference for the invalid-input problem type (v1): identity, recovery, applicability, and example envelope.",
+      "sidebarLabel": "invalid-input/v1"
+    },
+    {
+      "source": "docs/reference/errors/operation-failed.md",
+      "output": "errors/operation-failed/v1.mdx",
+      "title": "Operation failed",
+      "description": "Reference for the operation-failed problem type (v1): identity, recovery, applicability, and example envelope.",
+      "sidebarLabel": "operation-failed/v1"
     }
   ]
 }

--- a/site/scripts/docs-mapping.json
+++ b/site/scripts/docs-mapping.json
@@ -232,6 +232,13 @@
       "title": "Architecture & Design",
       "description": "Why the template is built the way it is: the crates/ layout, CI orchestration, attested delivery, and lint philosophy.",
       "sidebarLabel": "Architecture & Design"
+    },
+    {
+      "source": "docs/explanation/error-architecture.md",
+      "output": "explanation/error-architecture.mdx",
+      "title": "Dual-Consumer Error Output",
+      "description": "Why and how the crate emits errors for both humans and LLM agents via an RFC 9457 problem+json envelope with applicability markers and a dual renderer.",
+      "sidebarLabel": "Error Output (Dual-Consumer)"
     }
   ]
 }

--- a/site/src/content/docs/errors.mdx
+++ b/site/src/content/docs/errors.mdx
@@ -1,0 +1,28 @@
+---
+title: "Error Type Registry"
+description: "Canonical registry of the RFC 9457 problem types this crate emits, with dereferenceable type URIs."
+---
+
+The canonical registry of problem types this crate emits as RFC 9457
+`application/problem+json` envelopes. Each `type` URI below is dereferenceable —
+it resolves to its own reference page, which is the source of truth for that
+type's status, recovery action, and stability.
+
+| Problem type | Status | Exit code | Retryable |
+|---|---|---|---|
+| [Invalid input](https://zircote.com/rust-template/errors/invalid-input/v1) | 400 | 2 | No |
+| [Operation failed](https://zircote.com/rust-template/errors/operation-failed/v1) | 500 | 1 | No |
+
+For the envelope structure, applicability markers, and renderer selection, see
+the **Dual-Consumer Error Output** explanation.
+
+## Customizing the base URI
+
+This is a template, so the URI host is a single configurable knob, not a
+hardcoded string. The constant `ERROR_TYPE_BASE_URI` in `crates/problem.rs`
+holds the base (`https://zircote.com/rust-template/errors` by default); every
+type URI is derived as `{base}/{slug}/{version}`. An adopter sets that one
+constant to their own documentation host and all type URIs follow. The
+occurrence `instance` URN namespace is derived from the crate name
+(`CARGO_PKG_NAME`), so renaming the crate in `Cargo.toml` updates it
+automatically — no edit here.

--- a/site/src/content/docs/errors/invalid-input/v1.mdx
+++ b/site/src/content/docs/errors/invalid-input/v1.mdx
@@ -1,0 +1,68 @@
+---
+title: "Invalid input"
+description: "Reference for the invalid-input problem type (v1): identity, recovery, applicability, and example envelope."
+sidebar:
+  label: "invalid-input/v1"
+---
+
+`InvalidInput` — a value supplied to an operation did not satisfy a documented
+constraint, so the operation never ran.
+
+## Identity
+
+| Field      | Value                                                          |
+|------------|----------------------------------------------------------------|
+| Type URI   | `https://zircote.com/rust-template/errors/invalid-input/v1`    |
+| Title      | `Invalid input`                                                |
+| Status     | `400`                                                          |
+| Exit code  | `2`                                                            |
+| Retryable  | No — `retry_after` is `null` (non-transient).                  |
+
+## When it occurs
+
+Returned when a value fails validation *before* an operation runs — for example
+`divide(_, 0)` (the divisor cannot be zero). The `detail` member carries the
+occurrence-specific `Display` string, such as
+`invalid input: divisor cannot be zero`.
+
+## Recovery
+
+| Field             | Value                                                                   | Applicability       |
+|-------------------|-------------------------------------------------------------------------|---------------------|
+| `suggested_fix`   | Correct the input so it satisfies the documented constraints, then retry. | `maybe_incorrect`   |
+| `code_actions[0]` | Replace the offending input with a valid value (`quickfix`).            | `maybe_incorrect`   |
+
+The applicability is `maybe_incorrect`, not `machine_applicable`: the correct
+value is domain-specific, so a consumer must escalate to a human rather than
+substitute a value automatically.
+
+## Example envelope
+
+```json
+{
+  "type": "https://zircote.com/rust-template/errors/invalid-input/v1",
+  "title": "Invalid input",
+  "status": 400,
+  "detail": "invalid input: divisor cannot be zero",
+  "instance": "urn:rust_template:invalid-input",
+  "retry_after": null,
+  "suggested_fix": {
+    "description": "Correct the input so it satisfies the documented constraints, then retry.",
+    "applicability": "maybe_incorrect"
+  },
+  "code_actions": [
+    {
+      "title": "Replace the offending input with a valid value",
+      "kind": "quickfix",
+      "applicability": "maybe_incorrect"
+    }
+  ],
+  "exit_code": 2
+}
+```
+
+## Stability
+
+This is the `v1` definition. Its meaning is stable across releases; a breaking
+change to the type's semantics ships a new version (`/v2`) rather than redefining
+`v1`.

--- a/site/src/content/docs/errors/operation-failed/v1.mdx
+++ b/site/src/content/docs/errors/operation-failed/v1.mdx
@@ -1,0 +1,69 @@
+---
+title: "Operation failed"
+description: "Reference for the operation-failed problem type (v1): identity, recovery, applicability, and example envelope."
+sidebar:
+  label: "operation-failed/v1"
+---
+
+`OperationFailed` — a named operation could not complete. The inputs may have
+been individually valid, but the operation itself failed.
+
+## Identity
+
+| Field      | Value                                                             |
+|------------|-------------------------------------------------------------------|
+| Type URI   | `https://zircote.com/rust-template/errors/operation-failed/v1`    |
+| Title      | `Operation failed`                                                |
+| Status     | `500`                                                             |
+| Exit code  | `1`                                                               |
+| Retryable  | No — `retry_after` is `null` (non-transient).                     |
+
+## When it occurs
+
+Returned when an operation runs but cannot produce a result — for example
+`process("-7")` (a parsed value that is out of the operation's accepted range).
+The structured `OperationFailed` variant names the failing operation and its
+cause; the `detail` member carries the `Display` string, such as
+`operation 'process' failed: value -7 is negative`.
+
+## Recovery
+
+| Field             | Value                                                              | Applicability   |
+|-------------------|--------------------------------------------------------------------|-----------------|
+| `suggested_fix`   | Inspect the operation's operands; the operation could not complete. | `unspecified`   |
+| `code_actions[0]` | Adjust the operands so the operation can complete (`quickfix`).    | `unspecified`   |
+
+The applicability is `unspecified` — the safe floor. A consumer treats it as
+`maybe_incorrect` and escalates to a human; the cause is too general to prescribe
+a machine-applicable edit.
+
+## Example envelope
+
+```json
+{
+  "type": "https://zircote.com/rust-template/errors/operation-failed/v1",
+  "title": "Operation failed",
+  "status": 500,
+  "detail": "operation 'process' failed: value -7 is negative",
+  "instance": "urn:rust_template:operation-failed",
+  "retry_after": null,
+  "suggested_fix": {
+    "description": "Inspect the operation's operands; the operation could not complete.",
+    "applicability": "unspecified"
+  },
+  "code_actions": [
+    {
+      "title": "Adjust the operands so the operation can complete",
+      "kind": "quickfix",
+      "applicability": "unspecified"
+    }
+  ],
+  "exit_code": 1
+}
+```
+
+## Stability
+
+This is the `v1` definition. Its meaning is stable across releases; a breaking
+change to the type's semantics ships a new version (`/v2`) rather than redefining
+`v1`.

--- a/site/src/content/docs/explanation/error-architecture.mdx
+++ b/site/src/content/docs/explanation/error-architecture.mdx
@@ -1,0 +1,182 @@
+---
+title: "Dual-Consumer Error Output"
+description: "Why and how the crate emits errors for both humans and LLM agents via an RFC 9457 problem+json envelope with applicability markers and a dual renderer."
+sidebar:
+  label: "Error Output (Dual-Consumer)"
+---
+
+This document explains the error-output architecture that `rust_template` ships
+as a foundation for adopters: a single binary that serves **two** audiences from
+**one** error value. It covers why the architecture exists, the envelope fields,
+the applicability markers, the type-URI versioning policy, and how the dual
+renderer selects a format. For the source-level error conventions (`thiserror`,
+the `Result` alias, `?` propagation), see the **Error Handling** reference.
+
+## Why error output is a dual-consumer problem
+
+A command-line tool now answers to two distinct consumers:
+
+1. **The human** who ran the command and reads the terminal.
+2. **The LLM agent** that orchestrated the command, parses the bytes, and decides
+   whether to retry, escalate, or abandon.
+
+Most CLIs serve the first consumer well and the second poorly. That imbalance is
+not a polish problem — it is a cost, reliability, and convergence problem. A
+verbose traceback shipped into an agent's `tool_result` burns tokens (a 5 KB
+traceback is roughly 1,600 tokens; a structured envelope cuts that by about
+75 %). A transient error without a retry directive causes agents to abandon
+recoverable work. An unmarked "suggested fix" invites agents to apply
+plausible-looking but wrong edits.
+
+The architecture's response is the model from
+[RFC 9457 *Problem Details*](https://www.rfc-editor.org/rfc/rfc9457): the human
+keeps the lush `Display` line unchanged, and the agent gets a structured
+`application/problem+json` envelope carrying the standard members plus three
+agent-facing extensions. The two renderings come from one `Error` value, so they
+can never drift.
+
+## The envelope
+
+`ProblemDetails` is a serializable struct. It is hand-rolled on `serde` (no
+heavyweight diagnostic framework), keeping the dependency surface to `serde` and
+`serde_json`, both of which pass `cargo deny check`.
+
+### Standard members (RFC 9457)
+
+| Member     | Type         | Meaning                                                       |
+|------------|--------------|---------------------------------------------------------------|
+| `type`     | URI string   | Stable, versioned URI identifying the problem type.           |
+| `title`    | string       | Short human-readable summary. Stable per `type`.              |
+| `status`   | number       | Numeric status class (mirrored to the process `exit_code`).   |
+| `detail`   | string       | Explanation specific to this occurrence — the `Display` line. |
+| `instance` | URI string   | `urn:` reference identifying this specific occurrence.        |
+
+`detail` is the error's `Display` string, so the human rendering and the machine
+`detail` are the same text by construction.
+
+### Agent extensions (mandatory)
+
+| Extension       | Type           | Meaning                                                                                                          |
+|-----------------|----------------|------------------------------------------------------------------------------------------------------------------|
+| `retry_after`   | number \| null | Delta-seconds before a safe retry. **Explicitly `null`** on non-transient errors so an agent never has to guess. |
+| `suggested_fix` | object \| null | A recovery action with a description and an applicability marker.                                                 |
+| `code_actions`  | array          | Structured edits modeled on the LSP `CodeAction` interface.                                                       |
+
+`retry_after` is serialized even when absent (as JSON `null`). Both error
+variants the template ships today are non-transient, so they carry
+`retry_after: null`. An adopter modeling a rate-limit class sets it to a positive
+number with `ProblemDetails::with_retry_after`.
+
+### Optional extension
+
+| Extension   | Type   | Meaning                                            |
+|-------------|--------|----------------------------------------------------|
+| `exit_code` | number | The process exit code emitted alongside the error. |
+
+## Applicability markers
+
+Every `suggested_fix` and every `code_actions[]` entry carries an `Applicability`
+marker, modeled on the rustc diagnostic precedent. Without it, an agent cannot
+tell a safe auto-applicable edit from a guess.
+
+| Marker               | Agent contract                                                  |
+|----------------------|-----------------------------------------------------------------|
+| `machine_applicable` | Apply the edit and retry without human confirmation.            |
+| `maybe_incorrect`    | Escalate to a human before applying.                            |
+| `has_placeholders`   | The fix has slots the agent must fill; lower confidence.        |
+| `unspecified`        | Applicability unknown; consumers treat it as `maybe_incorrect`. |
+
+`unspecified` is the default and the safe floor: a missing or unknown marker is
+never treated as auto-applicable.
+
+## Type-URI versioning policy
+
+Each `Error` variant maps to a distinct, version-embedded `type` URI:
+
+| Variant           | Type URI                                         |
+|-------------------|--------------------------------------------------|
+| `InvalidInput`    | `https://zircote.com/errors/invalid-input/v1`    |
+| `OperationFailed` | `https://zircote.com/errors/operation-failed/v1` |
+
+The policy is a **commitment**: the meaning of a given URI never changes. The
+`/v1` segment is the version. A breaking change to a problem type's semantics
+ships a new `/v2` URI rather than redefining `/v1`. Agents that key behavior off
+a `type` URI can therefore rely on it across releases. The URIs are stable and
+distinct per variant, which lets agents branch on the problem type without
+parsing prose.
+
+## The dual renderer
+
+The binary ships **both** renderings and selects between them. Selection is
+`OutputFormat::select`, driven by an explicit `--format` flag first, then by
+stderr TTY detection:
+
+| `--format` | stderr is a TTY | Selected format |
+|------------|-----------------|-----------------|
+| `json`     | (ignored)       | JSON            |
+| `pretty`   | (ignored)       | Pretty          |
+| (absent)   | yes             | Pretty          |
+| (absent)   | no              | JSON            |
+
+The rationale for honoring both signals: a human at a terminal gets the lush line
+by default; the same binary, run by an agent or in a pipe (no TTY), emits the
+structured envelope without any flag. An explicit `--format` always wins, so a
+human can force JSON and an agent can force pretty when needed.
+
+The **pretty** rendering is byte-identical to the binary's historical
+`Error: {e}` line — adopting this architecture changes nothing for human users.
+The **JSON** rendering is the compact `application/problem+json` envelope.
+
+## Worked example
+
+The `InvalidInput` variant produced by `divide(10, 0)` renders two ways from the
+same value. Pretty:
+
+```text
+Error: invalid input: divisor cannot be zero
+```
+
+JSON (`application/problem+json`):
+
+```json
+{
+  "type": "https://zircote.com/errors/invalid-input/v1",
+  "title": "Invalid input",
+  "status": 400,
+  "detail": "invalid input: divisor cannot be zero",
+  "instance": "urn:rust_template:invalid-input",
+  "retry_after": null,
+  "suggested_fix": {
+    "description": "Correct the input so it satisfies the documented constraints, then retry.",
+    "applicability": "maybe_incorrect"
+  },
+  "code_actions": [
+    {
+      "title": "Replace the offending input with a valid value",
+      "kind": "quickfix",
+      "applicability": "maybe_incorrect"
+    }
+  ],
+  "exit_code": 2
+}
+```
+
+## Why this lives in the library
+
+The envelope, the mapping, and the format selector are all part of the library
+surface, not buried in the binary. An adopter building a different binary — or a
+service, or a second CLI — reuses `ProblemDetails`, `Error::to_problem`, and
+`OutputFormat` directly. The binary in `crates/main.rs` is just the first
+consumer of a reusable contract. The cost is a slightly larger public API; the
+benefit is that every project built from the template inherits a machine-readable
+error contract for free, rather than re-implementing one per binary.
+
+## Related reading
+
+- The **Error Handling** reference — the field tables and source conventions in
+  lookup form.
+- **Architecture & Design** — the broader "why" behind the template's layout, CI,
+  and lint philosophy.
+- [RFC 9457 — Problem Details for HTTP APIs](https://www.rfc-editor.org/rfc/rfc9457)
+- [LSP `CodeAction`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeAction)
+  — the shape `code_actions[]` follows.

--- a/site/src/content/docs/explanation/error-architecture.mdx
+++ b/site/src/content/docs/explanation/error-architecture.mdx
@@ -93,17 +93,30 @@ never treated as auto-applicable.
 
 Each `Error` variant maps to a distinct, version-embedded `type` URI:
 
-| Variant           | Type URI                                         |
-|-------------------|--------------------------------------------------|
-| `InvalidInput`    | `https://zircote.com/errors/invalid-input/v1`    |
-| `OperationFailed` | `https://zircote.com/errors/operation-failed/v1` |
+| Variant           | Type URI                                                       |
+|-------------------|----------------------------------------------------------------|
+| `InvalidInput`    | `https://zircote.com/rust-template/errors/invalid-input/v1`    |
+| `OperationFailed` | `https://zircote.com/rust-template/errors/operation-failed/v1` |
 
 The policy is a **commitment**: the meaning of a given URI never changes. The
-`/v1` segment is the version. A breaking change to a problem type's semantics
-ships a new `/v2` URI rather than redefining `/v1`. Agents that key behavior off
-a `type` URI can therefore rely on it across releases. The URIs are stable and
-distinct per variant, which lets agents branch on the problem type without
-parsing prose.
+`/v1` segment is the version, carried per problem type so one type can advance to
+`/v2` without disturbing the others. A breaking change to a type's semantics
+ships a new version rather than redefining the existing one. Agents that key
+behavior off a `type` URI can therefore rely on it across releases.
+
+Each URI is **dereferenceable**: it resolves to a live problem-type reference
+page (the documentation registry lives at
+`https://zircote.com/rust-template/errors/`). Those per-type pages are the source
+of truth for a type's status, recovery action, and stability — see the
+**Errors** reference.
+
+**Configurable for adopters.** Because this is a template, the URI host is not
+hardcoded across the code. A single constant, `ERROR_TYPE_BASE_URI`, holds the
+base (`https://zircote.com/rust-template/errors` by default); every type URI is
+derived as `{base}/{slug}/{version}`. An adopter points that one constant at
+their own documentation host and all type URIs follow. The occurrence `instance`
+URN namespace is derived from the crate name (`CARGO_PKG_NAME`), so renaming the
+crate in `Cargo.toml` updates it automatically.
 
 ## The dual renderer
 
@@ -140,7 +153,7 @@ JSON (`application/problem+json`):
 
 ```json
 {
-  "type": "https://zircote.com/errors/invalid-input/v1",
+  "type": "https://zircote.com/rust-template/errors/invalid-input/v1",
   "title": "Invalid input",
   "status": 400,
   "detail": "invalid input: divisor cannot be zero",

--- a/site/src/content/docs/reference/error-handling.mdx
+++ b/site/src/content/docs/reference/error-handling.mdx
@@ -6,4 +6,30 @@ description: "Error type design, Result alias, and propagation conventions."
 - **Crate error type**: `Error` enum derived with `thiserror::Error`.
 - **Result alias**: `pub type Result<T> = std::result::Result<T, Error>`.
 - **Propagation**: use `?` operator. Never `unwrap()`, `expect()`, or `panic!()` in library code.
-- **Binary**: `main()` returns `ExitCode`; delegates to `run() -> Result`. Match on `Ok`/`Err` in `main()` and print errors to stderr.
+- **Binary**: `main()` returns `ExitCode`; delegates to `run() -> Result`. On `Err`, the binary renders the error to stderr in the format selected by `--format` / TTY (below).
+
+#### Dual-Consumer Error Output (RFC 9457)
+
+The crate emits errors for two consumers from one `Error` value: the human (the `thiserror` `Display`, unchanged) and the LLM agent (a serializable `application/problem+json` envelope). The envelope type is `ProblemDetails` in `crates/problem.rs`, re-exported from the crate root alongside `Applicability`, `CodeAction`, `SuggestedFix`, and `OutputFormat`. Map any error with `Error::to_problem()`; render for a format with `Error::render(OutputFormat)`.
+
+**Envelope members** (`ProblemDetails`):
+
+| Field | RFC 9457 role | Notes |
+|---|---|---|
+| `type` | standard | Stable, version-embedded URI (`.../v1`). |
+| `title` | standard | Short summary, stable per `type`. |
+| `status` | standard | Numeric status class. |
+| `detail` | standard | This-occurrence text; equals the `Display` string. |
+| `instance` | standard | `urn:` occurrence reference. |
+| `retry_after` | agent extension | Delta-seconds, or `null` (serialized) on non-transient errors. |
+| `suggested_fix` | agent extension | `{ description, applicability }`, or `null`. |
+| `code_actions` | agent extension | Array of LSP-`CodeAction`-shaped `{ title, kind, applicability }`. |
+| `exit_code` | optional extension | Process exit code; omitted from JSON when absent. |
+
+**Applicability markers** (on every `suggested_fix` and `code_action`): `machine_applicable` (auto-apply), `maybe_incorrect` (escalate to human), `has_placeholders` (fill slots first), `unspecified` (default; treat as `maybe_incorrect`).
+
+**Type URIs** (one per variant, distinct, versioned): `InvalidInput` → `https://zircote.com/errors/invalid-input/v1`; `OperationFailed` → `https://zircote.com/errors/operation-failed/v1`. A breaking change ships a new `/v2` URI rather than redefining `/v1`.
+
+**Format selection** (`OutputFormat::select(explicit, is_terminal)`): JSON when `--format=json` or (no flag and stderr is not a TTY); pretty otherwise. Pretty output is byte-identical to the historical `Error: {e}` line.
+
+For the rationale, see the **Dual-Consumer Error Output** explanation doc (`docs/explanation/error-architecture.md`).

--- a/site/src/content/docs/reference/error-handling.mdx
+++ b/site/src/content/docs/reference/error-handling.mdx
@@ -28,7 +28,7 @@ The crate emits errors for two consumers from one `Error` value: the human (the 
 
 **Applicability markers** (on every `suggested_fix` and `code_action`): `machine_applicable` (auto-apply), `maybe_incorrect` (escalate to human), `has_placeholders` (fill slots first), `unspecified` (default; treat as `maybe_incorrect`).
 
-**Type URIs** (one per variant, distinct, versioned): `InvalidInput` → `https://zircote.com/errors/invalid-input/v1`; `OperationFailed` → `https://zircote.com/errors/operation-failed/v1`. A breaking change ships a new `/v2` URI rather than redefining `/v1`.
+**Type URIs** (one per variant, distinct, versioned): `InvalidInput` → `https://zircote.com/rust-template/errors/invalid-input/v1`; `OperationFailed` → `https://zircote.com/rust-template/errors/operation-failed/v1`. A breaking change ships a new version rather than redefining the existing one. The base is a single configurable constant, `ERROR_TYPE_BASE_URI` (derived URI = `{base}/{slug}/{version}`); adopters point it at their own docs host. Each URI is dereferenceable — it resolves to a per-type reference page under `docs/reference/errors/` (the canonical source). The `instance` URN namespace tracks `CARGO_PKG_NAME`.
 
 **Format selection** (`OutputFormat::select(explicit, is_terminal)`): JSON when `--format=json` or (no flag and stderr is not a TTY); pretty otherwise. Pretty output is byte-identical to the historical `Error: {e}` line.
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,8 @@
 //! Integration tests for `rust_template`.
 
-use rust_template::{Config, Error, Result, add, divide};
+use rust_template::{
+    Applicability, Config, Error, OutputFormat, ProblemDetails, Result, add, divide,
+};
 
 #[test]
 fn test_add_integration() {
@@ -88,6 +90,130 @@ fn process_numbers(a: i64, b: i64) -> Result<i64> {
 fn test_result_chaining() {
     let result = process_numbers(10, 6);
     assert_eq!(result.unwrap(), 8);
+}
+
+/// Tests for the RFC 9457 Problem Details error-output architecture, exercised
+/// across the crate boundary as a downstream consumer would.
+mod problem_envelope_tests {
+    use super::*;
+
+    /// One forced instance of every `Error` variant the public API can produce.
+    /// Built directly so this helper stays outside `#[test]` context without
+    /// tripping the `unwrap_used` lint; `divide`/`process` produce these exact
+    /// shapes (verified in `super::test_divide_by_zero` and the unit tests).
+    fn each_variant() -> Vec<Error> {
+        vec![
+            Error::InvalidInput("divisor cannot be zero".to_string()),
+            Error::OperationFailed {
+                operation: "process".to_string(),
+                cause: "value -7 is negative".to_string(),
+            },
+        ]
+    }
+
+    #[test]
+    fn envelope_carries_five_standard_members_and_three_extensions() {
+        for err in each_variant() {
+            let json = err.to_problem().to_json();
+            let value: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+
+            for member in ["type", "title", "status", "detail", "instance"] {
+                assert!(
+                    value.get(member).is_some(),
+                    "missing standard member {member}"
+                );
+            }
+            // retry_after is present even on non-transient errors (null), so the
+            // agent never has to guess whether the class is retryable.
+            assert!(value.get("retry_after").is_some());
+            assert!(value["retry_after"].is_null());
+            assert!(value.get("suggested_fix").is_some());
+            assert!(value.get("code_actions").is_some());
+        }
+    }
+
+    #[test]
+    fn every_suggested_fix_and_code_action_has_an_applicability_marker() {
+        for err in each_variant() {
+            let problem = err.to_problem();
+            assert!(problem.suggested_fix.is_some(), "missing suggested_fix");
+            assert!(!problem.code_actions.is_empty(), "missing code_actions");
+
+            let json = problem.to_json();
+            let value: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+            assert!(value["suggested_fix"]["applicability"].is_string());
+            for action in value["code_actions"].as_array().expect("array") {
+                assert!(action["applicability"].is_string());
+            }
+        }
+    }
+
+    #[test]
+    fn every_variant_has_a_distinct_versioned_type_uri() {
+        let uris: Vec<&str> = each_variant().iter().map(Error::type_uri).collect();
+        for uri in &uris {
+            assert!(uri.contains("/v1"), "type URI {uri} must embed a version");
+        }
+        // Distinctness: no two variants share a type URI.
+        for (i, a) in uris.iter().enumerate() {
+            for b in &uris[i + 1..] {
+                assert_ne!(a, b, "type URIs must be distinct across variants");
+            }
+        }
+    }
+
+    #[test]
+    fn dual_format_selection_picks_json_or_pretty() {
+        let err = divide(10, 0).unwrap_err();
+
+        // Pretty is byte-identical to the historical Display line.
+        let pretty = err.render(OutputFormat::select(Some("pretty"), false));
+        assert_eq!(pretty, format!("Error: {err}"));
+
+        // JSON is the problem+json envelope.
+        let json = err.render(OutputFormat::select(Some("json"), true));
+        assert_eq!(json, err.to_problem().to_json());
+
+        // Without a flag, TTY selects pretty and a pipe selects JSON.
+        assert_eq!(err.render(OutputFormat::select(None, true)), pretty);
+        assert_eq!(err.render(OutputFormat::select(None, false)), json);
+    }
+
+    #[test]
+    fn reusable_envelope_builds_a_transient_error() {
+        // A downstream adopter constructs its own envelope with retry_after.
+        let problem = ProblemDetails::new(
+            "https://example.com/errors/rate-limit/v1",
+            "Rate limit exceeded",
+            429,
+            "Exceeded rate limit for this endpoint.",
+            "urn:request:abc123",
+        )
+        .with_retry_after(180)
+        .with_exit_code(2);
+
+        let value: serde_json::Value =
+            serde_json::from_str(&problem.to_json()).expect("valid JSON");
+        assert_eq!(value["retry_after"], 180);
+        assert_eq!(value["status"], 429);
+    }
+
+    #[test]
+    fn applicability_default_is_unspecified() {
+        assert_eq!(Applicability::default(), Applicability::Unspecified);
+    }
+
+    /// Proof harness: prints the pretty and JSON renderings for every variant.
+    /// Run `cargo test --all-features print_dual_renderings -- --nocapture` to
+    /// see the evidence in the transcript.
+    #[test]
+    fn print_dual_renderings() {
+        for err in each_variant() {
+            println!("\n=== variant: {} ===", err.type_uri());
+            println!("[pretty]\n{}", err.render(OutputFormat::Pretty));
+            println!("[json]\n{}", err.to_problem().to_json_pretty());
+        }
+    }
 }
 
 mod property_tests {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -150,7 +150,7 @@ mod problem_envelope_tests {
 
     #[test]
     fn every_variant_has_a_distinct_versioned_type_uri() {
-        let uris: Vec<&str> = each_variant().iter().map(Error::type_uri).collect();
+        let uris: Vec<String> = each_variant().iter().map(Error::type_uri).collect();
         for uri in &uris {
             assert!(uri.contains("/v1"), "type URI {uri} must embed a version");
         }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,7 +1,7 @@
 //! Integration tests for `rust_template`.
 
 use rust_template::{
-    Applicability, Config, Error, OutputFormat, ProblemDetails, Result, add, divide,
+    Applicability, Config, Error, OutputFormat, ProblemDetails, Result, add, divide, process,
 };
 
 #[test]
@@ -201,6 +201,23 @@ mod problem_envelope_tests {
     #[test]
     fn applicability_default_is_unspecified() {
         assert_eq!(Applicability::default(), Applicability::Unspecified);
+    }
+
+    /// Pins the hand-built `each_variant()` shapes against the real error output
+    /// of `divide`/`process`, so a change to either variant's `Display` message
+    /// fails here rather than silently diverging from the literals the rest of
+    /// this suite asserts against.
+    #[test]
+    fn each_variant_matches_real_error_output() {
+        let variants = each_variant();
+        assert_eq!(
+            variants[0].to_string(),
+            divide(10, 0).unwrap_err().to_string()
+        );
+        assert_eq!(
+            variants[1].to_string(),
+            process("-7").unwrap_err().to_string()
+        );
     }
 
     /// Proof harness: prints the pretty and JSON renderings for every variant.


### PR DESCRIPTION
## Summary

Ships a reusable, **dual-consumer** (human + LLM-agent) error-output architecture per the cdc-err / RFC 9457 model — the foundation template adopters inherit. One `Error` value, two renderings: the human keeps the lush `Display` line; the agent gets a structured `application/problem+json` envelope it can parse to decide retry / escalate / abandon.

Draft — **do not merge without explicit human go-ahead.**

## What changed

**Library — `crates/problem.rs`** (re-exported from the crate root):
- `ProblemDetails`: serializable RFC 9457 envelope with the five standard members (`type`, `title`, `status`, `detail`, `instance`), the three agent extensions (`retry_after` — explicitly `null` on non-transient errors, `suggested_fix`, `code_actions[]`), and the optional `exit_code`.
- `Applicability` marker (`machine_applicable` | `maybe_incorrect` | `has_placeholders` | `unspecified`) on **every** suggested fix and code action.
- `Error::to_problem()` maps each variant to a distinct, version-embedded type URI. `Display` is **unchanged**.
- `OutputFormat::select()` + `Error::render()` so the contract is reusable beyond this binary.

**Configurable type URIs (template-first).** The URI host is a single knob, `ERROR_TYPE_BASE_URI`, not a hardcoded string. Each URI is derived as `{base}/{slug}/{version}`, so an adopter repoints one constant. The `instance` URN namespace derives from `CARGO_PKG_NAME`, so renaming the crate needs no code change. The default base (`https://zircote.com/rust-template/errors`) equals the Astro `site` + `base`, so **each type URI is a live, dereferenceable doc page**.

**Canonical per-type docs.** `docs/reference/errors/{README,invalid-input,operation-failed}.md` are the sole source for each problem type; they render to the site at slugs matching the URIs (`errors`, `errors/<slug>/v1`). `astro build` renders all three.

**Binary — `crates/main.rs`**: format selection via `--format pretty|json`, then stderr `IsTerminal` (JSON when `--format=json` or non-TTY; pretty otherwise). Pretty output is **byte-identical** to the historical `Error: {e}` line.

**Dependencies**: adds `serde` + `serde_json`; both pass `cargo deny check`.

**Docs**: new Diátaxis explanation doc + per-type reference registry; CLAUDE.md **Error Handling** reference updated.

## Sample renderings (`InvalidInput` via `divide(10, 0)`)

Pretty:
```text
Error: invalid input: divisor cannot be zero
```
JSON (`application/problem+json`):
```json
{
  "type": "https://zircote.com/rust-template/errors/invalid-input/v1",
  "title": "Invalid input",
  "status": 400,
  "detail": "invalid input: divisor cannot be zero",
  "instance": "urn:rust_template:invalid-input",
  "retry_after": null,
  "suggested_fix": { "description": "Correct the input so it satisfies the documented constraints, then retry.", "applicability": "maybe_incorrect" },
  "code_actions": [ { "title": "Replace the offending input with a valid value", "kind": "quickfix", "applicability": "maybe_incorrect" } ],
  "exit_code": 2
}
```

## Verification

- `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features`, `cargo doc --no-deps --all-features`, `cargo deny check` — all exit 0.
- Coverage: 97% lines / 95% functions (≥ 90% requirement).
- `cd site && npm run check:freshness` — exits 0; `astro build` renders all error pages at their URI paths.
- `git grep "zircote.com/errors"` (old base) — zero hits.

## Constraints honored

- `unsafe_code = "forbid"` and all clippy denials (`unwrap_used`/`expect_used`/`panic`/`print_*`) unchanged; binary keeps its existing `#[allow]`.
- Public signatures of `add`/`divide`/`process`/`Config` unchanged (additive only).
- No GitHub Actions changed; no history rewritten.