### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-17
+
+### Added
+
+- **errors**: Dual-consumer (human + LLM-agent) error output following the RFC 9457 Problem Details model
+  - `ProblemDetails` serializable envelope carrying the five standard members (`type`, `title`, `status`, `detail`, `instance`) plus the `retry_after`, `suggested_fix`, and `code_actions` agent extensions and an optional `exit_code`
+  - `Applicability` markers (`machine_applicable` / `maybe_incorrect` / `has_placeholders` / `unspecified`) on every suggested fix and code action
+  - `Error::to_problem()` maps each variant to a distinct, version-embedded type URI derived from the configurable `ERROR_TYPE_BASE_URI`; the occurrence `instance` URN tracks the crate name
+  - `OutputFormat` + `Error::render()` dual renderer; the binary selects JSON vs pretty via `--format` and stderr `IsTerminal` detection (pretty output is byte-identical to the prior `Error: {e}` line)
+  - Per-type problem documentation under `docs/reference/errors/` (dereferenceable type URIs) and a "Dual-Consumer Error Output" explanation doc
+
+### Build
+
+- Add `serde` and `serde_json` runtime dependencies for JSON envelope serialization
+
 ## [0.3.0] - 2026-06-17
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rust_template"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_template"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.92"
 description = "A Rust template crate with modern tooling and best practices"


### PR DESCRIPTION
Release **v0.4.0** (minor) — first release of the dual-consumer error architecture.

## Contents (since v0.3.0)

- **errors**: Dual-consumer (human + LLM-agent) error output per RFC 9457 (#116)
  - `ProblemDetails` envelope (5 standard members + `retry_after`/`suggested_fix`/`code_actions` + optional `exit_code`), `Applicability` markers, configurable `ERROR_TYPE_BASE_URI`, `OutputFormat`/`Error::render()` dual renderer, per-type reference docs.
- **Build**: adds `serde` + `serde_json` runtime deps.

All additive public API → minor bump, no breaking changes.

## Version locations updated

- `Cargo.toml` → 0.4.0, `Cargo.lock` regenerated, `CHANGELOG.md` 0.4.0 section.
- No `CITATION.cff`; `SECURITY.md` uses a `<version>` placeholder (no literal to bump).

## Operator note

`publish = false` — merging + tagging produces the **attested GitHub Release only** (5 binaries + SBOM + source snapshot + gate attestations, fail-closed verified). crates.io / container / Homebrew remain disabled (template state).