### PR TITLE
ci(docker): native per-arch builds + manifest (drop QEMU emulation)

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -11,10 +11,10 @@ name: Docker
     outputs:
       image-digest:
         description: >-
-          Manifest digest of the pushed image (sha256:...);
+          Manifest digest of the pushed multi-arch image (sha256:...);
           empty when push is false
         value: >-
-          ${{ jobs.build-and-push.outputs.image-digest }}
+          ${{ jobs.merge.outputs.image-digest }}
   workflow_dispatch:
     inputs:
       push:
@@ -26,27 +26,40 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
-# Least privilege: read-all at the top; the build-and-push job is granted
-# packages:write only because it pushes the image to GHCR (when push=true).
+# Least privilege: read-all at the top; the build and merge jobs are granted
+# packages:write only because they push the image to GHCR (when push=true).
 permissions:
   contents: read
 
 jobs:
-  build-and-push:
-    name: Build and Push Docker Image
-    runs-on: ubuntu-latest
+  # Build each architecture on its NATIVE runner (no QEMU emulation) — arm64
+  # on ubuntu-24.04-arm rather than emulated on x86, in parallel with amd64.
+  # When push=true each arch is pushed BY DIGEST and the merge job assembles
+  # the tagged manifest list. When push=false (PR / template state) the build
+  # is a cache-only validation that pushes nothing.
+  build:
+    name: Build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
-    outputs:
-      image-digest: ${{ steps.build.outputs.digest }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
     steps:
       - name: Checkout repository
         # v6.0.2
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
-      # Login must precede Buildx setup so the BuildKit builder image
-      # is pulled with credentials, not anonymously.
+      # Login must precede Buildx setup so the BuildKit builder image is
+      # pulled with credentials, not anonymously.
       - name: Log in to Container Registry
         if: inputs.push
         # v3.4.0
@@ -62,7 +75,94 @@ jobs:
         uses: >-
           docker/setup-buildx-action@7c525be6cc8a882d5163ce04293cac18617c709f
 
-      - name: Extract metadata
+      - name: Docker metadata (labels)
+        id: meta
+        # v6.0.0
+        uses: >-
+          docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
+        with:
+          images: >-
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build (push by digest when push=true)
+        id: build
+        # v6.10.0
+        uses: >-
+          docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Per-arch cache scope so amd64/arm64 layers don't evict each other.
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+          build-args: |
+            RUST_VERSION=1.92
+          # push=true -> push single-arch by digest (the merge job tags the
+          # manifest list); push=false -> cache-only validation, no push.
+          outputs: >-
+            ${{ inputs.push
+            && format('type=image,name=ghcr.io/{0},push-by-digest=true,name-canonical=true,push=true', github.repository)
+            || 'type=cacheonly' }}
+
+      - name: Export digest
+        if: inputs.push
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        if: inputs.push
+        # v7.0.1
+        uses: >-
+          actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the tagged multi-arch manifest list from the per-arch digests and
+  # resolve its digest (the subject pipeline.yml signs/attests). Only runs when
+  # push=true — there are no pushed digests to merge otherwise, so the
+  # image-digest output is empty in the build-only case.
+  merge:
+    name: Merge multi-arch manifest
+    needs: [build]
+    if: inputs.push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image-digest: ${{ steps.digest.outputs.digest }}
+    steps:
+      - name: Download digests
+        # v8.0.1
+        uses: >-
+          actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        # v3.9.0
+        uses: >-
+          docker/setup-buildx-action@7c525be6cc8a882d5163ce04293cac18617c709f
+
+      - name: Log in to Container Registry
+        # v3.4.0
+        uses: >-
+          docker/login-action@3227f5311cb93ffd14d13e65d8cc400d30f4dd8a
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata (tags)
         id: meta
         # v6.0.0
         uses: >-
@@ -79,18 +179,28 @@ jobs:
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push Docker image
-        id: build
-        # v6.10.0
-        uses: >-
-          docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: ${{ inputs.push }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            RUST_VERSION=1.92
+      - name: Create and push manifest list
+        working-directory: /tmp/digests
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2046
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' \
+              <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Resolve manifest-list digest
+        id: digest
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          digest=$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          if [ -z "$digest" ]; then
+            echo "::error::failed to resolve manifest-list digest"
+            exit 1
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "manifest-list digest: ${digest}"


### PR DESCRIPTION
Transfers nsip's validated native multi-arch pattern to the template's container reusable.

**Before:** single job, `platforms: linux/amd64,linux/arm64` — arm64 emulated under QEMU on x86 (~50min).

**After:** `build` matrix on native runners (amd64 → ubuntu-latest, arm64 → ubuntu-24.04-arm), in parallel, per-arch GHA cache scope. When `push=true` each arch pushes by digest and a `merge` job assembles the tagged manifest list; when `push=false` (PR / template state) it's a cache-only validation that pushes nothing. The reusable's `image-digest` output now carries the manifest-list digest, so `pipeline.yml` (sign → verify → Trivy gate → container-scan attest) is unchanged.

Pattern validated end-to-end in zircote/nsip (build amd64+arm64 + merge + sign + verify + gate + attest all green, ~6min build vs ~50min emulated). Uses the template's existing action pins.