### PR TITLE
ci(docker): static musl on distroless/static (root-cause CVE fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,53 @@
 # Build stage
+# Alpine is musl-native, so `cargo build` produces a fully STATIC binary —
+# letting the runtime stage be distroless/static (no glibc/openssl/libstdc++)
+# and eliminating the base-image OS-package CVEs a glibc image (distroless/cc)
+# otherwise carries.
+#
 # Base images are pinned by digest (OpenSSF Scorecard: Pinned-Dependencies).
 # The :tag is kept alongside the digest for human readability; Dependabot's
 # docker ecosystem keeps the digest fresh. Refresh with:
 #   docker buildx imagetools inspect <image> --format '{{.Manifest.Digest}}'
-FROM rust:1.96-slim@sha256:3b05f7c617a200c41c3506097f0d15fc193a1c93bfd8f141007b47cac8f95d3c AS builder
+FROM rust:1.96-alpine@sha256:f87aa870663e2b57ec8c69de82c7eedf7383bee987eef7612c0359635eaadb41 AS builder
+
+# musl-dev + build-base provide the C toolchain/assembler for any C-backed
+# crates a downstream project adds (e.g. ring); the musl target links them
+# statically. (A pure-Rust project needs neither, but the template should
+# build out of the box once dependencies are added.)
+RUN apk add --no-cache musl-dev build-base
 
 WORKDIR /app
-
-# Install build dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    pkg-config \
-    libssl-dev \
-    && rm -rf /var/lib/apt/lists/*
 
 # Copy manifests
 COPY Cargo.toml Cargo.lock ./
 
-# Create dummy source to cache dependencies
-RUN mkdir -p crates && \
+# Create dummy source to cache dependencies. The explicit [[bench]] target
+# (benches/benchmarks.rs) must exist or cargo fails at manifest parse, so stub
+# it too — not just crates/.
+RUN mkdir -p crates benches && \
     echo "fn main() {}" > crates/main.rs && \
-    echo "pub fn add(a: i64, b: i64) -> i64 { a + b }" > crates/lib.rs
+    echo "pub fn add(a: i64, b: i64) -> i64 { a + b }" > crates/lib.rs && \
+    echo "fn main() {}" > benches/benchmarks.rs
 
-# Build dependencies (this layer will be cached)
+# Build dependencies (this layer will be cached). Keep the benches/ stub: it
+# is .dockerignored (not in the build context), but the explicit [[bench]]
+# target must exist for the manifest to parse. The release build never
+# compiles it.
 RUN cargo build --release && \
     rm -rf crates/
 
-# Copy actual source code
+# Copy actual source code (benches/ stub stays from the step above)
 COPY crates/ ./crates/
 
 # Build actual binary
 RUN cargo build --release
 
-# Runtime stage - use distroless for minimal attack surface.
-# Pinned by digest (no :latest) to satisfy Scorecard Pinned-Dependencies and
-# Trivy DS-0001; Dependabot's docker ecosystem keeps the digest fresh.
-FROM gcr.io/distroless/cc-debian12@sha256:d703b626ba455c4e6c6fbe5f36e6f427c85d51445598d564652a2f334179f96e
+# Runtime stage - distroless/static (no glibc/openssl) for the static musl
+# binary. Pinned by digest (no :latest) to satisfy Scorecard
+# Pinned-Dependencies and Trivy DS-0001; Dependabot keeps the digest fresh.
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
 
-# Copy binary from builder
+# Copy the statically-linked binary from builder
 COPY --from=builder /app/target/release/rust_template /usr/local/bin/rust_template
 
 # Set non-root user


### PR DESCRIPTION
Transfers nsip's static-musl Dockerfile pattern. Builds a fully STATIC musl binary (rust:1.96-alpine) onto distroless/static-debian12 (no glibc/openssl/libstdc++), eliminating base-image OS-package CVEs at the root instead of suppressing them.

Base images stay digest-pinned (Scorecard Pinned-Dependencies / Trivy DS-0001). Also fixes a latent bug in the dummy-dependency cache step: the explicit `[[bench]]` target made cargo fail at manifest-parse when benches/ was absent (benches/ is .dockerignored) — now stubbed so the manifest parses; the release build never compiles it.

Validated by local build (native arm64): binary `statically linked`, runs on distroless/static, Trivy HIGH/CRITICAL = 0. Note: the template's container build is dormant (publish=false), so this isn't exercised in-repo; downstream instantiations (publish=true) inherit the zero-CVE base.